### PR TITLE
ci(dependabot): remove auto-approve and require manual approvals

### DIFF
--- a/.github/DEPENDABOT_APPROVAL.md
+++ b/.github/DEPENDABOT_APPROVAL.md
@@ -1,23 +1,18 @@
-# Dependabot PR Auto-Approval
+# Dependabot PR Approval Policy
 
-This project auto-runs a Dependabot PR validation workflow that attempts to auto-approve Dependabot PRs.
+Automatic approval steps have been removed from the Dependabot validation workflow by design — maintainers must review and approve Dependabot PRs manually.
 
-If the `juliangruber/approve-pull-request-action@v2` step fails with **"Resource not accessible by integration"** or a similar permission error, follow these steps:
+How to approve a Dependabot PR
 
-1. Repository Workflow Permissions
-   - Go to: Settings → Actions → General → Workflow permissions
-   - Ensure **Allow GitHub Actions to create and approve pull requests** (or equivalent) is enabled. This is required for `GITHUB_TOKEN` to create PR reviews.
+1. Open the pull request on GitHub (Pull requests → select PR).
+2. Review the CI job results and the code changes.
+3. Click **Review changes** → choose **Approve** and submit the review.
 
-2. Branch Protection
-   - If branch protection rules limit who can approve, adjust them so that approvals from Actions or token-based automation are permitted when needed.
+Re-enabling automatic approvals (optional)
 
-3. Fallback with PAT (optional)
-   - If your organization restricts workflow permissions and you still want automatic approvals, create a Personal Access Token (PAT) with `repo` scope and add it as a repository secret named `PERSONAL_TOKEN`.
-   - The Dependabot workflow includes a fallback step that will use `PERSONAL_TOKEN` to approve the PR if the primary approve action fails.
+- If you want automatic approvals again in the future, we recommend using a Fine‑grained token scoped to this repository (or a classic PAT with minimal `repo` scope). Add it as the secret `PERSONAL_TOKEN` and reintroduce the approval step.
+- Note: automatic approvals can be risky; prefer manual review for higher assurance.
 
-4. Security Note
-   - Using a PAT is less preferred than enabling Actions permissions because a PAT is a long-lived credential. Use it only when necessary and rotate it regularly.
+Security note
 
-5. Troubleshooting
-   - After changing settings, re-run the Dependabot workflow (Actions → select run → Re-run jobs).
-   - Check the workflow logs for the approve step and the fallback step to see whether approval succeeded and which token was used.
+- Use the minimal permissions required and set a short expiration date for any token. Rotate tokens regularly and never commit them into the repository.

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -53,32 +53,8 @@ jobs:
             - name: Validate README
               run: ./scripts/validate_readme.sh
 
-            - name: Auto-approve Dependabot PR (primary)
-              id: auto_approve
+            - name: Note: manual approval required
               if: success()
-              uses: juliangruber/approve-pull-request-action@v2
-              continue-on-error: true
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  number: ${{ github.event.pull_request.number }}
-
-            - name: Auto-approve Dependabot PR (fallback via PAT)
-              if: ${{ failure() && secrets.PERSONAL_TOKEN != '' }}
               run: |
-                  # Fallback: use a Personal Access Token (repo scope) stored in secrets.PERSONAL_TOKEN
-                  PR_NUMBER=${{ github.event.pull_request.number }}
-                  REPO_FULL=${{ github.repository }}
-
-                  echo "Fallback: approving PR #$PR_NUMBER using PERSONAL_TOKEN"
-
-                  curl -s -X POST "https://api.github.com/repos/${REPO_FULL}/pulls/${PR_NUMBER}/reviews" \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "Authorization: Bearer ${{ secrets.PERSONAL_TOKEN }}" \
-                    -d '{"event":"APPROVE", "body":"Auto-approved by CI fallback token."}' | jq '.'
-
-            - name: Auto-approve Dependabot PR (report failure)
-              if: ${{ failure() && secrets.PERSONAL_TOKEN == '' }}
-              run: |
-                  echo "Auto-approve failed with GITHUB_TOKEN and no PERSONAL_TOKEN provided."
-                  echo "Please add a repository secret 'PERSONAL_TOKEN' (repo scope) if you want automatic approvals as fallback."
-                  exit 1
+                  echo "Automatic approval was intentionally removed from this workflow."
+                  echo "Maintainers must review and manually approve Dependabot PRs if CI passes."


### PR DESCRIPTION
Remove automatic approval steps and PAT fallback from Dependabot validation workflow. Maintainers must now review and approve Dependabot PRs manually. Update docs in .github/DEPENDABOT_APPROVAL.md to reflect the policy.