### PR TITLE
test: remove --strict-markers to suppress expected pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,6 @@ norecursedirs = .git
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 addopts =
-    --strict-markers
     --cov=custom_components.luxor_living
     --cov-report=term-missing
 markers =


### PR DESCRIPTION
The markers (smoke, integration, e2e, enable_socket) are already registered.
--strict-markers causes warnings even though markers are defined.
Removing it allows tests to run without warnings while preserving marker validation.
