### PR TITLE
refactor(release): separate formatting checks from release notes verification

### DIFF
--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -32,6 +32,12 @@ jobs:
           python -m pip install -r requirements_dev.txt
           python -m pip install black isort
 
+      - name: Check code formatting (black)
+        run: black --check custom_components tests scripts
+
+      - name: Check import sorting (isort)
+        run: isort --check-only custom_components tests scripts
+
       - name: Quick smoke tests
         run: |
           python -m pytest tests/ -q -m "smoke and not enable_socket"

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -1,31 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Prefer local virtualenv binaries if present
-if [ -d "venv/bin" ]; then
-  PATH="venv/bin:$PATH"
-elif [ -d ".venv/bin" ]; then
-  PATH=".venv/bin:$PATH"
-fi
-
 # check_release_notes.sh
 # Verify that a RELEASE_NOTES_v<version>.md file exists and contains the version heading
-
-# Formatting guards (prevent releasing unformatted code)
-if ! command -v black >/dev/null 2>&1; then
-  echo "Missing dependency: black" >&2
-  exit 1
-fi
-if ! command -v isort >/dev/null 2>&1; then
-  echo "Missing dependency: isort" >&2
-  exit 1
-fi
-
-echo "Running black --check ..."
-black --check custom_components tests scripts
-
-echo "Running isort --check-only ..."
-isort --check-only custom_components tests scripts
+# Note: Code formatting checks (black/isort) are handled separately in release_checks workflow
 
 MANIFEST="custom_components/luxor_living/manifest.json"
 if [ ! -f "$MANIFEST" ]; then


### PR DESCRIPTION
- Remove black/isort checks from check_release_notes.sh (script now only verifies release notes file)
- Add explicit black and isort check steps to release_checks.yml workflow
- This prevents false failures when formatting differs between environments
- Focuses check_release_notes.sh on its single responsibility
