### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ documented in this file.
 
 ---
 
+## [1.0.0] - 2026-03-22
+
+### Added
+
+- **Gold Quality Scale**: icon translations (`icons.json`), exception translations (`HomeAssistantError` with `translation_key`), zeroconf discovery (`_knxip._udp.local.`), docs use-cases and known-limitations sections
+- **Options flow sections**: Standard options (scan interval, log level, simulation mode) and collapsible Push Webhook advanced section via `data_entry_flow.section()`
+- **Persona documentation**: `USER_GUIDE.md`, `ADVANCED_GUIDE.md`, `DEVELOPER_GUIDE.md`, `REFERENCE.md` — replaces scattered per-audience docs
+- **README hub**: short hub README with 3-step quickstart, persona router, absolute doc links
+
+### Changed
+
+- **Docs overhaul**: archived 15 outdated/duplicate files; all doc links use absolute `/blob/main/` URLs (avoids 404 on old release tags)
+- **Translation sync**: `strings.json`, `en.json`, `de.json`, `fr.json` updated for all new options fields and zeroconf confirm step
+
+---
+
 ## [0.8.0] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v0.8.0](https://github.com/phismith91/luxorliving/releases/tag/v0.8.0)
+**Current release:** [v1.0.0](https://github.com/phismith91/luxorliving/releases/tag/v1.0.0)
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -1,14 +1,26 @@
 {
   "domain": "luxor_living",
   "name": "LUXORliving",
-  "codeowners": ["@phismith91"],
+  "codeowners": [
+    "@phismith91"
+  ],
   "config_flow": true,
-  "dependencies": ["file_upload", "http"],
+  "dependencies": [
+    "file_upload",
+    "http"
+  ],
   "documentation": "https://github.com/phismith91/luxorliving",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/phismith91/luxorliving/issues",
-  "requirements": ["xknx>=3.13.0", "defusedxml>=0.7.1"],
-  "version": "0.8.0",
-  "zeroconf": [{"type": "_knxip._udp.local."}]
+  "requirements": [
+    "xknx>=3.13.0",
+    "defusedxml>=0.7.1"
+  ],
+  "version": "1.0.0",
+  "zeroconf": [
+    {
+      "type": "_knxip._udp.local."
+    }
+  ]
 }

--- a/docs/releases/RELEASE_NOTES_v1.0.0.md
+++ b/docs/releases/RELEASE_NOTES_v1.0.0.md
@@ -1,0 +1,29 @@
+# LUXORliving v1.0.0 — Gold Quality Scale & Documentation Overhaul
+
+## Highlights
+
+First stable release. Achieves full **HA Integration Quality Scale Gold** compliance
+and ships a complete documentation rewrite with persona-based guides.
+
+## Added
+
+- **Gold Quality Scale**: icon translations (`icons.json`), exception translations
+  (`HomeAssistantError` with `translation_key`), zeroconf discovery
+  (`_knxip._udp.local.`), docs use-cases and known-limitations sections
+- **Options flow sections**: Standard options (scan interval, log level, simulation
+  mode) and collapsible Push Webhook advanced section
+- **Persona documentation**: `USER_GUIDE.md`, `ADVANCED_GUIDE.md`,
+  `DEVELOPER_GUIDE.md`, `REFERENCE.md` — replaces scattered per-audience docs
+- **README hub**: short hub README with 3-step quickstart and persona router
+
+## Changed
+
+- **Docs overhaul**: archived 15 outdated/duplicate files; all doc links use
+  absolute `/blob/main/` URLs (avoids 404 on old release tags)
+- **Translation sync**: `strings.json`, `en.json`, `de.json`, `fr.json` updated
+  for all new options fields and zeroconf confirm step
+
+## Upgrade Notes
+
+- Install v1.0.0 via HACS and restart Home Assistant
+- No breaking changes — existing config entries are fully compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "luxor-living"
-version = "0.6.3"
+version = "1.0.0"
 description = "Theben LUXORliving integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bump `manifest.json` + `pyproject.toml` version: `0.8.0` → `1.0.0`
- Add `[1.0.0]` CHANGELOG entry with Gold Quality Scale / docs changes
- Update README `RELEASE_NOTES` block to reference `v1.0.0`

## Changes included in v1.0.0

- Gold Quality Scale: icon translations, exception translations, zeroconf discovery
- Options flow sections (standard/advanced collapsible)
- Persona documentation (USER_GUIDE, ADVANCED_GUIDE, DEVELOPER_GUIDE, REFERENCE)
- Docs overhaul: archived 15 outdated files, absolute doc links

🤖 Generated with [Claude Code](https://claude.com/claude-code)