### PR TITLE
chore(release): bump version to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ documented in this file.
 
 ---
 
+## [1.1.4] - 2026-05-04
+
+### Fixed
+
+- Cover and climate entities crash on setup with AttributeError: MappedEntity has no attribute get
+  (MappedEntity is a dataclass, not a dict — use attribute access instead)
+- KNX listener registration moved to async_added_to_hass (was in __init__ which runs in a
+  thread executor, causing thread-safety and lifecycle issues with async_write_ha_state)
+- async_will_remove_from_hass cleanup prevents stale listeners and memory leaks on reload
+- Temperature DPT encoding: removed incorrect x100/÷100 integer conversion; gateway already
+  decodes DPT 9.001 as Python float
+- StopStep → StepStop typo in platform_detector.py ROLE_TO_PLATFORM mapping
+- device_info: remove non-existent device_model/sw_version fields; use model=LUXORliving
+
+---
+
 ## [1.1.3] - 2026-03-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.1.3](https://github.com/phismith91/luxorliving/releases/tag/v1.1.3)
+**Current release:** [v1.1.4](https://github.com/phismith91/luxorliving/releases/tag/v1.1.4)
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -17,7 +17,7 @@
     "xknx>=3.13.0",
     "defusedxml>=0.7.1"
   ],
-  "version": "1.1.3",
+  "version": "1.1.4",
   "zeroconf": [
     {
       "type": "_knxip._udp.local."

--- a/docs/releases/RELEASE_NOTES_v1.1.4.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.4.md
@@ -1,0 +1,21 @@
+# Release Notes — v1.1.4
+
+## Fixed
+
+- **Cover and climate entities crash on setup** (`AttributeError: 'MappedEntity' object has no attribute 'get'`).
+  `MappedEntity` is a dataclass — switched from dict `.get()` calls to direct attribute access
+  (`.datapoints`, `.unique_id`, `.name`, `.device_id`, `.device_name`).
+
+- **KNX listener lifecycle**: Registration moved from `__init__` (runs in a thread executor) to
+  `async_added_to_hass`, preventing thread-safety issues and premature `async_write_ha_state()` calls.
+  Added `async_will_remove_from_hass` to clean up listeners on integration reload.
+
+- **Temperature DPT encoding**: Removed incorrect ×100/÷100 integer encoding. The KNX gateway
+  already decodes DPT 9.001 as Python `float` — temperature values are now passed directly.
+
+- **`StopStep` → `StepStop`** typo in `platform_detector.py` `ROLE_TO_PLATFORM` mapping.
+
+- **`device_info`**: Removed non-existent `device_model`/`sw_version` fields; using `model="LUXORliving"`.
+
+- **Gateway API alignment**: Cover and climate now use `async_send_telegram` / `async_read_group_address`
+  (listener-driven pattern), consistent with light and switch platforms.


### PR DESCRIPTION
## Release 1.1.4

**Bug fix release** — Covers and climate entities are now functional.

### Changes in this release (via #122)

**Critical fix:**
- `LuxorCover` and `LuxorClimate` crashed on setup with `AttributeError: 'MappedEntity' object has no attribute 'get'`
- KNX listener registration moved to `async_added_to_hass` (thread-safety + HA lifecycle compliance)
- `async_will_remove_from_hass` added for proper listener cleanup on reload

**Also fixed:**
- Temperature DPT encoding: gateway already returns `float`, removed incorrect ×100/÷100 math
- `StopStep` → `StepStop` typo in `platform_detector.py`
- Removed non-existent `device_model`/`sw_version` fields from `device_info`
- Gateway calls now use `async_send_telegram` / `async_read_group_address` (aligned with light/switch)

**Tests:** 731 passing