### PR TITLE
feat: Theben RTR 718 standalone thermostat → climate entity (v1.1.7)

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -87,8 +87,9 @@
 2. **[2026-05-16] Climate entity detection requires two conditions** H6 heating
    actuator: `heizungsart` param + `Istwert` + `Sollwert` datapoints. RTR
    thermostat: `activateRTR=1` param + `Istwert` + (`Sollwert` or
-   `status@Sollwert`). Do instead: when H6/climate stops working, check
-   `entity_mapper._map_actuator` first.
+   `status@Sollwert`). R718 standalone thermostat: `Istwert` + `Sollwert` +
+   `status@Sollwert` (no `activateRTR`). Do instead: when climate stops working,
+   check `entity_mapper._map_sensor` and `_map_actuator` first.
 
 3. **[2026-05-16] KNX listeners must be registered in `async_added_to_hass`, not
    `__init__`** `__init__` may run in an executor (thread-unsafe for
@@ -96,7 +97,14 @@
    `knx_gateway.register_listener(...)` + initial read in `async_added_to_hass`;
    unregister in `async_will_remove_from_hass`.
 
-4. **[2026-05-16] Debounce tasks must be cancelled on `async_disconnect`**
+4. **[2026-05-16] knxprod DB ist die autoritative Gerätedatenbank** Alle 57
+   LUXORliving-Geräte + vollständige Datapoint/DPT-Definitionen in
+   `docs/LUXORliving_ETS5_KNX_DB_V2_23_2510.knxprod_FILES/`. Issue #131 trackt
+   den Plan, `appId` aus LXP gegen Catalog.xml abzugleichen statt Parameter-
+   Heuristiken. Do instead: bevor neue Geräteerkennung per Heuristik
+   implementiert wird — erst in `M-0048/M-0048_A-<appId>.xml` nachschauen.
+
+5. **[2026-05-16] Debounce tasks must be cancelled on `async_disconnect`**
    Lingering `asyncio.Task` from `_execute_debounced_callbacks` causes HA test
    framework failures. Do instead: `async_disconnect` cancels `_debounce_task` —
    don't remove that line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ documented in this file.
 
 ---
 
+## [1.1.7] - 2026-05-16
+
+### Added
+
+- **Theben RTR 718 thermostat support**: The RTR 718 is a standalone room thermostat device
+  (distinct from iON panel RTR channels). It is now automatically detected and mapped to a
+  `climate` entity via its three characteristic datapoints (`Istwert`, `Sollwert`,
+  `status@Sollwert`). The optional `UmschaltenHeitzenKühlen` datapoint (heating/cooling mode
+  switch) is passed through to the entity for future use.
+
+---
+
 ## [1.1.6] - 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 756](https://img.shields.io/badge/Tests-756%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 761](https://img.shields.io/badge/Tests-761%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors, switches and binary sensors, all created without any manual YAML.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.1.6](https://github.com/phismith91/luxorliving/releases/tag/v1.1.6) — Cover position inversion fixed · BWM/BI motion sensor state now live · Wetterstation rain sensor added
+**Current release:** [v1.1.7](https://github.com/phismith91/luxorliving/releases/tag/v1.1.7) — RTR 718 thermostat support · B6 binary input fix · Rain sensor live state
 <!-- RELEASE_NOTES_END -->
 
 ---
@@ -62,6 +62,7 @@ Tested and confirmed working:
 | D 2 / D 4 | Dimming actuator | `light` (with brightness) |
 | J 4 / J 8 | Blind / shutter actuator | `cover` (position + tilt) |
 | H 6 | Heating actuator | `climate` (setpoint + valve) |
+| RTR 718 | Standalone room thermostat | `climate` (setpoint + current temp) |
 | KNX weather station | Multi-sensor | `sensor` (temperature, wind, brightness) |
 | Motion detectors | Binary input | `binary_sensor` |
 | Window / door contacts | Binary input | `binary_sensor` |

--- a/custom_components/luxor_living/entity_mapper.py
+++ b/custom_components/luxor_living/entity_mapper.py
@@ -204,6 +204,40 @@ class EntityMapper:
             self._map_wetterstation_sensor(device, sensor, datapoints)
             return
 
+        # R718 standalone thermostat: Istwert + Sollwert + status@Sollwert (no activateRTR param)
+        # Theben RTR 718 is a dedicated room thermostat device, distinct from iON panel RTR
+        if (
+            "Istwert" in datapoints
+            and "Sollwert" in datapoints
+            and "status@Sollwert" in datapoints
+            and sensor.parameters.get("activateRTR") != "1"
+        ):
+            istwert_addr = datapoints["Istwert"]
+            self._claimed_climate_istwert_addresses.add(istwert_addr)
+            unique_id = f"{device.id}_{istwert_addr}"
+            name = sensor.name or f"{device.name} Ch{sensor.channel}"
+            if name.startswith(device.name + " "):
+                name = name[len(device.name) + 1 :]
+            entity = MappedEntity(
+                platform=Platform.CLIMATE,
+                unique_id=unique_id,
+                name=name,
+                device_name=device.name,
+                device_id=device.id,
+                entity_type="climate",
+                datapoints=datapoints,
+                attributes={
+                    "channel": sensor.channel,
+                    "sensor_type": sensor.sensor_type,
+                    "serial_number": device.serial_number,
+                    "knx_address": device.address,
+                },
+                parameters=sensor.parameters,
+            )
+            self.entities.append(entity)
+            _LOGGER.debug("Mapped R718 thermostat '%s' to climate", name)
+            return
+
         # RTR thermostat detection: activateRTR=1 + Istwert + (Sollwert or status@Sollwert)
         if (
             sensor.parameters.get("activateRTR") == "1"

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -17,7 +17,7 @@
     "xknx>=3.13.0",
     "defusedxml>=0.7.1"
   ],
-  "version": "1.1.6",
+  "version": "1.1.7",
   "zeroconf": [
     {
       "type": "_knxip._udp.local."

--- a/docs/releases/RELEASE_NOTES_v1.1.7.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.7.md
@@ -1,0 +1,10 @@
+# Release Notes — v1.1.7
+
+## Added
+
+- **Theben RTR 718 thermostat support**: The RTR 718 is a standalone room thermostat device
+  (distinct from iON panel RTR channels with `activateRTR=1`). It is now automatically detected
+  and mapped to a `climate` entity via its three characteristic datapoints (`Istwert`, `Sollwert`,
+  `status@Sollwert`). The optional `UmschaltenHeitzenKühlen` datapoint (heating/cooling mode
+  switch) is passed through to the entity for future use. Duplicate prevention applies: if an
+  H6 actuator shares the same `Istwert` address, the R718 takes precedence.

--- a/tests/test_entity_mapper_extended.py
+++ b/tests/test_entity_mapper_extended.py
@@ -438,3 +438,74 @@ class TestClimateMapping:
         mapper = _mapper([sensor_device, actuator_device])
         climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
         assert len(climate_entities) == 1
+
+
+class TestR718ThermostatMapping:
+    def test_maps_r718_to_climate(self):
+        """R718 sensor with Istwert+Sollwert+status@Sollwert but no activateRTR → Platform.CLIMATE."""
+        dp_ist = _datapoint("Istwert", 7680)
+        dp_soll = _datapoint("Sollwert", 7424)
+        dp_status = _datapoint("status@Sollwert", 7936)
+        sensor = _sensor("7 R718 105", 0, [dp_ist, dp_soll, dp_status])
+        sensor.parameters = {"abgleichwert": "0"}
+        device = _device("7 R718 105", sensors=[sensor])
+        mapper = _mapper([device])
+        climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
+        assert len(climate_entities) == 1
+        assert climate_entities[0].entity_type == "climate"
+
+    def test_r718_climate_has_correct_datapoints(self):
+        """R718 climate entity exposes all three thermostat datapoints."""
+        dp_ist = _datapoint("Istwert", 7680)
+        dp_soll = _datapoint("Sollwert", 7424)
+        dp_status = _datapoint("status@Sollwert", 7936)
+        sensor = _sensor("R718", 0, [dp_ist, dp_soll, dp_status])
+        sensor.parameters = {"abgleichwert": "0"}
+        device = _device("R718 Dev", sensors=[sensor])
+        mapper = _mapper([device])
+        entity = mapper.get_entities_by_platform(Platform.CLIMATE)[0]
+        assert entity.datapoints["Istwert"] == 7680
+        assert entity.datapoints["Sollwert"] == 7424
+        assert entity.datapoints["status@Sollwert"] == 7936
+
+    def test_r718_with_umschalten_has_umschalten_datapoint(self):
+        """R718 with UmschaltenHeitzenKühlen datapoint passes it through to entity."""
+        dp_ist = _datapoint("Istwert", 7680)
+        dp_soll = _datapoint("Sollwert", 7424)
+        dp_status = _datapoint("status@Sollwert", 7936)
+        dp_umschalten = _datapoint("UmschaltenHeitzenKühlen", 8192)
+        sensor = _sensor("R718", 0, [dp_ist, dp_soll, dp_status, dp_umschalten])
+        sensor.parameters = {"abgleichwert": "0"}
+        device = _device("R718 Dev", sensors=[sensor])
+        mapper = _mapper([device])
+        entity = mapper.get_entities_by_platform(Platform.CLIMATE)[0]
+        assert entity.datapoints["UmschaltenHeitzenKühlen"] == 8192
+
+    def test_sensor_with_only_istwert_and_sollwert_not_r718(self):
+        """Sensor with Istwert+Sollwert but no status@Sollwert is not mapped as R718 climate."""
+        dp_ist = _datapoint("Istwert", 7680)
+        dp_soll = _datapoint("Sollwert", 7424)
+        sensor = _sensor("Plain Temp", 0, [dp_ist, dp_soll])
+        sensor.parameters = {}
+        device = _device("Dev", sensors=[sensor])
+        mapper = _mapper([device])
+        climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
+        assert len(climate_entities) == 0
+
+    def test_no_duplicate_when_r718_and_actuator_share_istwert(self):
+        """R718 sensor takes precedence; H6 actuator with same Istwert address is skipped."""
+        shared = 7680
+        dp_ist_s = _datapoint("Istwert", shared)
+        dp_soll_s = _datapoint("Sollwert", 7424)
+        dp_status_s = _datapoint("status@Sollwert", 7936)
+        sensor = _sensor("R718", 0, [dp_ist_s, dp_soll_s, dp_status_s])
+        sensor.parameters = {"abgleichwert": "0"}
+        dp_ist_a = _datapoint("Istwert", shared)
+        dp_soll_a = _datapoint("Sollwert", 7424)
+        actuator = _actuator("H6", 0, [dp_ist_a, dp_soll_a])
+        actuator.parameters = {"heizungsart": "230"}
+        s_dev = _device("R718 Dev", sensors=[sensor], device_id="r718_dev")
+        a_dev = _device("H6 Dev", actuators=[actuator], device_id="h6_dev")
+        mapper = _mapper([s_dev, a_dev])
+        climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
+        assert len(climate_entities) == 1


### PR DESCRIPTION
## Summary

- Detects Theben RTR 718 dedicated room thermostats via `Istwert` + `Sollwert` + `status@Sollwert` datapoints (no `activateRTR` parameter needed — distinct from iON panel RTR channels)
- `UmschaltenHeitzenKühlen` datapoint is passed through for future heating/cooling mode support (v1.2.x)
- Duplicate prevention: R718 claims the Istwert address before H6 actuator mapping
- 5 new tests in `TestR718ThermostatMapping`, all RED-verified before implementation

## Test plan

- [ ] All 761 tests passing in CI
- [ ] Release Checks green (badge 761, version 1.1.7)
- [ ] HACS validation green

🤖 Generated with [Claude Code](https://claude.com/claude-code)