### PR TITLE
fix: code-review followups for v1.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 764](https://img.shields.io/badge/Tests-764%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 765](https://img.shields.io/badge/Tests-765%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors, switches and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/binary_sensor.py
+++ b/custom_components/luxor_living/binary_sensor.py
@@ -177,6 +177,8 @@ class LuxorLivingBinarySensor(LuxorLivingEntity, BinarySensorEntity):
             return BinarySensorDeviceClass.MOTION
         if entity_type == "health":
             return BinarySensorDeviceClass.CONNECTIVITY
+        if entity_type == "regen":
+            return BinarySensorDeviceClass.MOISTURE
 
         # Check name for keywords
         if "rauchmelder" in entity_name or "smoke" in entity_name:

--- a/custom_components/luxor_living/entity_mapper.py
+++ b/custom_components/luxor_living/entity_mapper.py
@@ -60,6 +60,12 @@ class EntityMapper:
 
     def map_all(self) -> list[MappedEntity]:
         """Map all devices to entities."""
+        if self._overrides.get("map_onoff_to_binary") is not None:
+            _LOGGER.warning(
+                "Override key 'map_onoff_to_binary' is no longer needed and will be ignored. "
+                "All sensor OnOff channels now always map to binary_sensor. "
+                "Remove this key from your luxor_living_overrides.yaml."
+            )
         _LOGGER.info("Mapping %d devices to entities", len(self.project.devices))
 
         for device in self.project.devices:
@@ -213,6 +219,13 @@ class EntityMapper:
             and sensor.parameters.get("activateRTR") != "1"
         ):
             istwert_addr = datapoints["Istwert"]
+            if istwert_addr in self._claimed_climate_istwert_addresses:
+                _LOGGER.debug(
+                    "Skipping R718 sensor '%s' — Istwert address %s already claimed",
+                    sensor.name,
+                    istwert_addr,
+                )
+                return
             self._claimed_climate_istwert_addresses.add(istwert_addr)
             unique_id = f"{device.id}_{istwert_addr}"
             name = sensor.name or f"{device.name} Ch{sensor.channel}"

--- a/docs/SENSOR_PLATFORM.md
+++ b/docs/SENSOR_PLATFORM.md
@@ -230,7 +230,7 @@ Hinweis zu `include_unaffected`:
 
 ```yaml
 include_unaffected: true  # optional: Parser nimmt auch affected=0 auf
-map_onoff_to_binary: true # optional: OnOff-Kontakte als binary_sensor
+# map_onoff_to_binary: true  # DEPRECATED since v1.1.7 — no longer needed, all sensor OnOff channels always map to binary_sensor
 
 sensors:
    - name: "Außentemperatur"

--- a/docs/luxor_living_overrides.example.yaml
+++ b/docs/luxor_living_overrides.example.yaml
@@ -3,7 +3,7 @@
 # Adjust addresses and names as needed.
 
 include_unaffected: true
-map_onoff_to_binary: true
+# map_onoff_to_binary: true  # DEPRECATED since v1.1.7 — all sensor OnOff channels now always map to binary_sensor
 
 sensors:
   # Wetterstation 1

--- a/tests/test_entity_mapper_extended.py
+++ b/tests/test_entity_mapper_extended.py
@@ -513,6 +513,19 @@ class TestR718ThermostatMapping:
         climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
         assert len(climate_entities) == 0
 
+    def test_activate_rtr_zero_with_status_sollwert_maps_as_r718(self):
+        """activateRTR=0 (not '1') + status@Sollwert → treated as R718, not iON RTR."""
+        dp_ist = _datapoint("Istwert", 7680)
+        dp_soll = _datapoint("Sollwert", 7424)
+        dp_status = _datapoint("status@Sollwert", 7936)
+        sensor = _sensor("Thermostat", 0, [dp_ist, dp_soll, dp_status])
+        sensor.parameters = {"activateRTR": "0"}
+        device = _device("Dev", sensors=[sensor])
+        mapper = _mapper([device])
+        climate_entities = mapper.get_entities_by_platform(Platform.CLIMATE)
+        assert len(climate_entities) == 1
+        assert climate_entities[0].platform == Platform.CLIMATE
+
     def test_no_duplicate_when_r718_and_actuator_share_istwert(self):
         """R718 sensor takes precedence; H6 actuator with same Istwert address is skipped."""
         shared = 7680


### PR DESCRIPTION
## Summary

Follow-up fixes from post-merge code review of v1.1.7 changes.

- **R718 dedup guard**: skip R718 climate entity if the `Istwert` address is already claimed by an H6 actuator — prevents a theoretical duplicate climate entity
- **Rain sensor `MOISTURE` device class**: `entity_type == "regen"` now returns `BinarySensorDeviceClass.MOISTURE` (water-drop icon, semantic automation support)
- **`map_onoff_to_binary` deprecation warning**: logs a `WARNING` when the now-obsolete override key is present in `luxor_living_overrides.yaml`, directing users to remove it
- **Docs**: key marked as deprecated in `SENSOR_PLATFORM.md` and `luxor_living_overrides.example.yaml`
- **Test**: `activateRTR=0` + `status@Sollwert` → correctly mapped as R718 climate

## Test plan

- [ ] All 765 tests pass
- [ ] Release Checks / validate_readme.sh gate passes (badge 765)
- [ ] No regressions in existing R718, H6, B6, rain sensor tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)