### PR TITLE
fix: resolve all 10 CodeQL security findings

### DIFF
--- a/.github/workflows/e2e_consent.yml
+++ b/.github/workflows/e2e_consent.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-consent:
     name: E2E Consent (manual)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   precommit:
     name: Pre-commit checks

--- a/.github/workflows/qa_matrix.yml
+++ b/.github/workflows/qa_matrix.yml
@@ -7,6 +7,9 @@ on:
 # To run the full QA matrix on a PR add the `run-qa-matrix` label to the PR.
 # This prevents the expensive matrix from running on every push/sync.
 
+permissions:
+  contents: read
+
 jobs:
   matrix-tests:
     name: QA matrix — Python ${{ matrix.python }} / HA ${{ matrix.ha }}

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -11,6 +11,9 @@ on:
 # This workflow runs: smoke & integration tests, HACS validation, release notes verification,
 # and shell scripts linting. Format checks run in PR workflows to keep this lean.
 
+permissions:
+  contents: read
+
 jobs:
   release_checks:
     name: Release Checks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Weekly on Sunday at midnight UTC
 
+permissions:
+  contents: read
+
 jobs:
   bandit:
     name: Python Security Scan

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 771](https://img.shields.io/badge/Tests-771%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 772](https://img.shields.io/badge/Tests-772%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors, switches and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/rest_client.py
+++ b/custom_components/luxor_living/rest_client.py
@@ -131,7 +131,7 @@ class BAOSRestClient:
         url = f"{self.base_url}/rest/login"
         payload = {"username": username, "password": password}
 
-        _LOGGER.debug(f"Attempting login to {url} with payload: {payload}")
+        _LOGGER.debug(f"Attempting login to {url} with user: {username}")
 
         try:
             async with self._session.post(url, json=payload) as response:

--- a/tests/test_rest_client_extended.py
+++ b/tests/test_rest_client_extended.py
@@ -241,6 +241,28 @@ class TestBAOSRestClientUnit:
         with pytest.raises(AuthenticationError):
             await c.async_get_datapoint_value(1)
 
+    @pytest.mark.asyncio
+    async def test_login_debug_log_omits_password(self):
+        """Ensure the login debug log never contains the password (CodeQL S2068)."""
+        c = BAOSRestClient("10.0.0.1", use_https=False)
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="test_token_abc")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_response)
+        c._session = mock_session
+
+        with patch("custom_components.luxor_living.rest_client._LOGGER") as mock_logger:
+            await c.login("admin", "s3cr3t")
+
+        logged_messages = " ".join(str(call) for call in mock_logger.debug.call_args_list)
+        assert "s3cr3t" not in logged_messages
+        assert "admin" in logged_messages
+
 
 # ── Integration tests with mock HTTP server ───────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **HIGH**: Remove password from debug log in `rest_client.py:134` — `payload` dict containing credentials was written to logs in plain text
- **MEDIUM (×9)**: Add `permissions: contents: read` to 5 workflow files — without explicit permissions, `GITHUB_TOKEN` inherits repo-default write access, enabling privilege escalation via compromised dependencies

## Changes

| File | Finding | Fix |
|------|---------|-----|
| `custom_components/luxor_living/rest_client.py` | Clear-text logging (HIGH) | Log only `username`, not full payload |
| `.github/workflows/security.yml` | Missing permissions (MEDIUM ×3) | `permissions: contents: read` |
| `.github/workflows/qa_matrix.yml` | Missing permissions (MEDIUM ×3) | `permissions: contents: read` |
| `.github/workflows/release_checks.yml` | Missing permissions (MEDIUM ×1) | `permissions: contents: read` |
| `.github/workflows/pre-commit.yml` | Missing permissions (MEDIUM ×1) | `permissions: contents: read` |
| `.github/workflows/e2e_consent.yml` | Missing permissions (MEDIUM ×1) | `permissions: contents: read` |

## Test plan

- [ ] Pre-commit hooks pass (black, isort, flake8, bandit) ✅ already verified locally
- [ ] CI workflows still execute correctly with restricted permissions (artifact uploads use `ACTIONS_RUNTIME_TOKEN`, unaffected)
- [ ] CodeQL findings close after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)