### PR TITLE
fix: resolve all 21 mypy 2.1.0 type errors

### DIFF
--- a/custom_components/luxor_living/__init__.py
+++ b/custom_components/luxor_living/__init__.py
@@ -107,7 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Create type-safe integration state
             state = IntegrationState(
                 mapper=mapper,
-                config=entry.data,
+                config=dict(entry.data),
                 overrides=overrides,
                 entry=entry,
             )

--- a/custom_components/luxor_living/binary_sensor.py
+++ b/custom_components/luxor_living/binary_sensor.py
@@ -109,7 +109,7 @@ class LuxorLivingBinarySensor(LuxorLivingEntity, BinarySensorEntity):
         )
 
         # KNX listener ref for cleanup (populated in async_added_to_hass)
-        self._knx_listener_addr: int | None = None
+        self._knx_listener_addr: str | None = None
 
         _LOGGER.debug(
             "📊 Binary Sensor '%s' (class: %s) status address: %s",
@@ -142,7 +142,8 @@ class LuxorLivingBinarySensor(LuxorLivingEntity, BinarySensorEntity):
 
     def _handle_knx_state(self, address: Any, value: Any) -> None:
         """Handle KNX telegram for this binary sensor's status address."""
-        self.coordinator.set_state(self._address_status, bool(value))
+        if self._address_status is not None:
+            self.coordinator.set_state(self._address_status, bool(value))
 
     @property
     def is_on(self) -> bool:
@@ -156,7 +157,9 @@ class LuxorLivingBinarySensor(LuxorLivingEntity, BinarySensorEntity):
             return True
         else:
             # Default: use coordinator data
-            return self.coordinator.get_state(self._address_status)
+            if self._address_status is None:
+                return False
+            return bool(self.coordinator.get_state(self._address_status))
 
     def _detect_device_class(self, mapped_entity: Any) -> BinarySensorDeviceClass | None:
         """Detect the device class based on entity type and name.

--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -419,7 +419,7 @@ class LuxorLivingOptionsFlow(OptionsFlow):
             if CONF_LOG_LEVEL in flat_input:
                 await self._async_update_log_level(flat_input[CONF_LOG_LEVEL])
 
-            return self.async_create_entry(title="", data=flat_input)
+            return self.async_create_entry(title="", data=flat_input)  # type: ignore[return-value]
 
         # Get current values from config_entry (provided by OptionsFlow base class)
         current_simulation_mode = self.config_entry.options.get(
@@ -538,7 +538,7 @@ class LuxorLivingOptionsFlow(OptionsFlow):
             }
         )
 
-        return self.async_show_form(
+        return self.async_show_form(  # type: ignore[return-value]
             step_id="init",
             data_schema=options_schema,
         )

--- a/custom_components/luxor_living/diagnostics.py
+++ b/custom_components/luxor_living/diagnostics.py
@@ -51,7 +51,7 @@ async def async_get_config_entry_diagnostics(
     coordinator = data.get("coordinator")
     overrides = data.get("overrides", {})
 
-    diagnostics = {
+    diagnostics: dict[str, Any] = {
         "diagnostics_allowed": True,
         "config_entry": {
             "entry_id": entry.entry_id,
@@ -98,7 +98,7 @@ async def async_get_config_entry_diagnostics(
         try:
             entities = getattr(mapper, "entities", [])
             entity_list: list[dict[str, Any]] = []
-            diagnostics["entities"] = entity_list  # type: ignore
+            diagnostics["entities"] = entity_list
 
             # Collect entity details (limit to 50 for performance)
             for entity in entities[:50]:

--- a/custom_components/luxor_living/entity_mapper.py
+++ b/custom_components/luxor_living/entity_mapper.py
@@ -139,10 +139,11 @@ class EntityMapper:
             self._claimed_climate_istwert_addresses.add(istwert_addr)
         else:
             # Determine platform based on primary roles
-            platform = self._determine_platform(datapoints)
-            if platform is None:
+            determined_platform = self._determine_platform(datapoints)
+            if determined_platform is None:
                 _LOGGER.debug("Skipping actuator %s - no mappable roles", actuator.name)
                 return
+            platform = determined_platform
 
             # Determine entity type
             if platform == Platform.LIGHT:
@@ -323,8 +324,8 @@ class EntityMapper:
 
         # Generate unique ID - use the first datapoint address to ensure uniqueness
         # Different sensors can have same name but different addresses
-        address = list(datapoints.values())[0] if datapoints else "unknown"
-        unique_id = f"{device.id}_{address}"
+        primary_addr: str | int = list(datapoints.values())[0] if datapoints else "unknown"
+        unique_id = f"{device.id}_{primary_addr}"
 
         # Generate friendly name
         name = sensor.name or f"{device.name} Ch{sensor.channel}"

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -281,7 +281,7 @@ class LuxorKNXGateway:
             elif value_type == "temperature":
                 # DPT 9.001 (2-byte float for temperature in °C)
                 encoded = DPT2ByteFloat().to_knx(float(value))
-                payload = GroupValueWrite(DPTArray(encoded))
+                payload = GroupValueWrite(encoded)
             else:
                 # For now, treat unknown types as raw bytes
                 payload = GroupValueWrite(

--- a/custom_components/luxor_living/overrides.py
+++ b/custom_components/luxor_living/overrides.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 try:
-    import yaml  # type: ignore
+    import yaml
 except Exception:  # pragma: no cover - optional dependency
     yaml = None
 

--- a/custom_components/luxor_living/repairs.py
+++ b/custom_components/luxor_living/repairs.py
@@ -57,7 +57,7 @@ class LuxorLivingAuthenticationRepairFlow(RepairsFlow):
 
         if user_input is not None:
             # Test credentials
-            host = self.entry.data.get(CONF_HOST)
+            host: str = self.entry.data[CONF_HOST]
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
 

--- a/custom_components/luxor_living/sensor.py
+++ b/custom_components/luxor_living/sensor.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
         ]
     )
 
-    async_add_entities(lxp_entities + discovered_entities)
+    async_add_entities([*lxp_entities, *discovered_entities])
 
 
 async def _create_lxp_sensor_entity(
@@ -288,7 +288,7 @@ class LuxorLivingDiscoveredSensor(SensorEntity):
             UnitOfTemperature,
         )
 
-        type_config = {
+        type_config: dict[str, dict[str, Any]] = {
             "temperature": {
                 "device_class": SensorDeviceClass.TEMPERATURE,
                 "unit": UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
## Summary

Fixes all 21 mypy errors surfaced by the `mypy 2.1.0` upgrade (dependabot PR #137). Without this, merging #137 would break the mypy step in CI.

## Changes by file

| File | Error | Fix |
|------|-------|-----|
| `binary_sensor.py` | `_knx_listener_addr: int\|None` (wrong type), None-unsafe `set_state`/`get_state` calls | Fix type to `str\|None`, add None guards |
| `sensor.py` | `list + tuple` concat, `object` not indexable in `type_config` | Unpack via `[*a, *b]`, add `dict[str, Any]` annotation |
| `diagnostics.py` | `object` not indexable (nested dict access), stale `# type: ignore` | Type `diagnostics` as `dict[str, Any]`, remove comment |
| `entity_mapper.py` | `Platform\|None` assigned to `Platform`, `str\|int` type annotation | Split assignment for narrowing, use `primary_addr: str\|int` |
| `config_flow.py` | HA internal `ConfigFlowResult` vs `FlowResult` mismatch | `# type: ignore[return-value]` (HA framework type) |
| `__init__.py` | `MappingProxyType` passed where `dict` expected | `dict(entry.data)` |
| `knx_gateway.py` | `DPTArray` double-wrapped in `DPTArray()` | Pass result directly to `GroupValueWrite` |
| `repairs.py` | `Any\|None` for `CONF_HOST` | Direct key access (always present in valid config entry) |
| `overrides.py` | Stale `# type: ignore` on yaml import | Remove comment |

## Test plan

- [ ] `mypy custom_components/luxor_living/ --ignore-missing-imports` → `Success: no issues found in 26 source files` ✅ verified locally
- [ ] `pre-commit run --all-files` → all hooks pass ✅ verified locally
- [ ] 733 tests passing (2 pre-existing failures unrelated to this PR) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)