### PR TITLE
deps(deps-dev): bump black from 26.5.0 to 26.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pytest-timeout>=2.4.0",
     "pytest-homeassistant-custom-component>=0.13.325",
     "zeroconf",
-    "black==26.5.0",
+    "black==26.5.1",
     "isort==7.0.0",
     "flake8==7.3.0",
     "flake8-docstrings==1.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "homeassistant>=2026.4.4",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    "pytest-asyncio>=1.4.0",
+    "pytest-asyncio>=1.3.0",
     "pytest-timeout>=2.4.0",
     "pytest-homeassistant-custom-component>=0.13.325",
     "zeroconf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "homeassistant>=2026.4.4",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    "pytest-asyncio>=1.3.0",
+    "pytest-asyncio>=1.4.0",
     "pytest-timeout>=2.4.0",
     "pytest-homeassistant-custom-component>=0.13.325",
     "zeroconf",


### PR DESCRIPTION
Applies two pending Dependabot updates that could not be auto-merged due to stale CI (branch was BEHIND after #147 moved deps to pyproject.toml).

- `pytest-asyncio`: `>=1.3.0` → `>=1.4.0` (closes #146)
- `black`: `==26.5.0` → `==26.5.1` (closes #143)

Both are patch/minor bumps with no breaking changes.