### PR TITLE
fix(config_flow): replace async_update_reload_and_abort with async_update_and_abort

### DIFF
--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -312,7 +312,7 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except Exception:
                 errors["base"] = "invalid_auth"
             else:
-                return self.async_update_reload_and_abort(
+                return self.async_update_and_abort(
                     reauth_entry,
                     data_updates={
                         CONF_USERNAME: user_input[CONF_USERNAME],
@@ -352,7 +352,7 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_lxp"
             else:
                 reconfigure_entry = self._get_reconfigure_entry()
-                return self.async_update_reload_and_abort(
+                return self.async_update_and_abort(
                     reconfigure_entry,
                     data_updates={
                         CONF_LXP_FILE: lxp_file,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -313,7 +313,8 @@ class TestReauthFlow:
             with patch.object(flow, "_validate_credentials", return_value=None):
                 with patch.object(
                     flow,
-                    "async_update_reload_and_abort",
+                    "async_update_and_abort",
+                    create=True,
                     return_value={"type": "abort", "reason": "reauth_successful"},
                 ) as mock_update:
                     result = await flow.async_step_reauth_confirm(
@@ -379,7 +380,8 @@ class TestReconfigureFlow:
                 ):
                     with patch.object(
                         flow,
-                        "async_update_reload_and_abort",
+                        "async_update_and_abort",
+                        create=True,
                         return_value={"type": "abort", "reason": "reconfigure_successful"},
                     ) as mock_update:
                         result = await flow.async_step_reconfigure({"lxp_file": "new-file-id"})


### PR DESCRIPTION
Fixes a deprecation warning introduced in HA 2026.6 (becomes a hard error in **HA 2026.12**).

## Problem

Using `add_update_listener` (in `__init__.py`) together with `async_update_reload_and_abort` (in reauth/reconfigure config flows) is deprecated. The combination causes the integration to reload twice and can create a race condition:

1. `async_update_reload_and_abort` → calls `async_update_entry` → fires `add_update_listener` → `async_reload` (1st)
2. `async_update_reload_and_abort` → calls `async_reload` again (2nd)

## Fix

Migration per [HA dev blog option 2](https://developers.home-assistant.io/blog/2026/05/07/config-entry-listener-together-with-reloading-methods):

- `async_update_reload_and_abort` → `async_update_and_abort` in `async_step_reauth_confirm` and `async_step_reconfigure`
- `add_update_listener` in `__init__.py` stays — it handles the single reload for both options changes and reauth/reconfigure data updates

## Result

All three flows (options, reauth, reconfigure) trigger exactly **one** reload via the listener.