### PR TITLE
fix(ui): improve config flow and options form selectors

### DIFF
--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -70,14 +70,43 @@ STEP_LXP_DATA_SCHEMA = vol.Schema(
     }
 )
 
-# Step 2: Gateway configuration with authentication
+# Step 2: Gateway configuration — Tunneling (with credentials)
 STEP_GATEWAY_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_HOST, default="192.168.1.3"): str,
+        vol.Required(CONF_HOST, default="192.168.1.3"): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        ),
         vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-        vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
+        vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
         vol.Required(
             CONF_CONNECTION_TYPE, default=DEFAULT_CONNECTION_TYPE
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[
+                    selector.SelectOptionDict(
+                        value=CONNECTION_TYPE_TUNNELING, label="Tunneling (BAOS REST API)"
+                    ),
+                    selector.SelectOptionDict(
+                        value=CONNECTION_TYPE_ROUTING, label="Routing (KNX/IP)"
+                    ),
+                ],
+                mode=selector.SelectSelectorMode.LIST,
+            )
+        ),
+        vol.Optional(CONF_SIMULATION_MODE, default=False): bool,
+    }
+)
+
+# Step 2 variant — Routing (no credentials needed)
+STEP_GATEWAY_ROUTING_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST, default="192.168.1.3"): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        ),
+        vol.Required(
+            CONF_CONNECTION_TYPE, default=CONNECTION_TYPE_ROUTING
         ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[
@@ -241,12 +270,13 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             # Combine LXP file and gateway config
+            connection_type = user_input.get(CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE)
             data = {
                 CONF_LXP_FILE: self._lxp_file,
                 CONF_HOST: user_input[CONF_HOST],
-                CONF_USERNAME: user_input[CONF_USERNAME],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-                CONF_CONNECTION_TYPE: user_input[CONF_CONNECTION_TYPE],
+                CONF_USERNAME: user_input.get(CONF_USERNAME, DEFAULT_USERNAME),
+                CONF_PASSWORD: user_input.get(CONF_PASSWORD, DEFAULT_PASSWORD),
+                CONF_CONNECTION_TYPE: connection_type,
                 CONF_SIMULATION_MODE: user_input.get(CONF_SIMULATION_MODE, False),
             }
 
@@ -260,9 +290,13 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         default_host = self._discovered_host or "192.168.1.3"
         gateway_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default=default_host): str,
+                vol.Required(CONF_HOST, default=default_host): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                ),
                 vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-                vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
+                vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                ),
                 vol.Required(
                     CONF_CONNECTION_TYPE, default=DEFAULT_CONNECTION_TYPE
                 ): selector.SelectSelector(
@@ -320,12 +354,16 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+        reauth_entry = self._get_reauth_entry()
+        current_username = reauth_entry.data.get(CONF_USERNAME, DEFAULT_USERNAME)
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-                    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
+                    vol.Required(CONF_USERNAME, default=current_username): str,
+                    vol.Required(CONF_PASSWORD, default=DEFAULT_PASSWORD): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                    ),
                 }
             ),
             errors=errors,
@@ -473,7 +511,9 @@ class LuxorLivingOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
                     default=current_scan_interval,
-                ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=5, max=300, step=1, unit_of_measurement="s")
+                ),
                 vol.Optional(
                     CONF_SIMULATION_MODE,
                     default=current_simulation_mode,
@@ -485,11 +525,25 @@ class LuxorLivingOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_LOG_LEVEL,
                     default=current_log_level,
-                ): vol.In(["debug", "info", "warning", "error"]),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(value="debug", label="Debug"),
+                            selector.SelectOptionDict(value="info", label="Info"),
+                            selector.SelectOptionDict(value="warning", label="Warning"),
+                            selector.SelectOptionDict(value="error", label="Error"),
+                        ],
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
                 vol.Optional(
                     CONF_DISCOVERY_TIMEOUT,
                     default=current_discovery_timeout,
-                ): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=10.0)),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0.5, max=10.0, step=0.5, unit_of_measurement="s"
+                    )
+                ),
                 # Advanced: Push Webhook — collapsed by default
                 vol.Required("push_webhook"): section(
                     vol.Schema(

--- a/custom_components/luxor_living/strings.json
+++ b/custom_components/luxor_living/strings.json
@@ -74,8 +74,8 @@
           "push_webhook": "Push Webhook",
           "push_ws_url": "WebSocket URL",
           "push_auth_method": "Authentication Method",
-          "push_token": "Token / Secret",
-          "push_ws_token": "WebSocket Bearer Token"
+          "push_token": "Incoming Token / HMAC Secret",
+          "push_ws_token": "Outgoing WebSocket Bearer Token"
         },
         "data_description": {
           "scan_interval": "How often to poll the gateway for state updates (5–300 seconds). With Push Webhook active, 60–120 s is sufficient.",
@@ -86,8 +86,8 @@
           "push_webhook": "Optional: receive real-time KNX state updates from an external forwarder instead of relying solely on polling.",
           "push_ws_url": "WebSocket URL of an external KNX forwarder (e.g. ws://192.168.1.100:8765). Leave empty to disable.",
           "push_auth_method": "Authentication method for incoming push HTTP requests: none, token, bearer, or hmac.",
-          "push_token": "Shared secret for token / hmac authentication.",
-          "push_ws_token": "Bearer token sent when connecting to the WebSocket URL."
+          "push_token": "Shared secret verified on incoming push requests (token / hmac auth).",
+          "push_ws_token": "Bearer token sent outbound when connecting to the WebSocket URL."
         }
       }
     }

--- a/custom_components/luxor_living/translations/de.json
+++ b/custom_components/luxor_living/translations/de.json
@@ -81,8 +81,8 @@
           "push_webhook": "Push Webhook",
           "push_ws_url": "WebSocket-URL",
           "push_auth_method": "Authentifizierungsmethode",
-          "push_token": "Token / Secret",
-          "push_ws_token": "WebSocket Bearer Token"
+          "push_token": "Eingehender Token / HMAC-Secret",
+          "push_ws_token": "Ausgehender WebSocket Bearer Token"
         },
         "data_description": {
           "scan_interval": "Wie oft der Gateway nach Statusänderungen abgefragt wird (5–300 Sekunden). Mit Push Webhook reichen 60–120 s.",
@@ -93,8 +93,8 @@
           "push_webhook": "Optional: Echtzeit-KNX-Statusupdates von einem externen Forwarder empfangen statt nur Polling.",
           "push_ws_url": "WebSocket-URL eines externen KNX-Forwarders (z. B. ws://192.168.1.100:8765). Leer lassen zum Deaktivieren.",
           "push_auth_method": "Authentifizierungsmethode für eingehende Push-HTTP-Anfragen: none, token, bearer oder hmac.",
-          "push_token": "Gemeinsames Secret für Token- / HMAC-Authentifizierung.",
-          "push_ws_token": "Bearer Token, der beim Verbinden mit der WebSocket-URL gesendet wird."
+          "push_token": "Gemeinsames Secret zur Prüfung eingehender Push-Anfragen (token / hmac).",
+          "push_ws_token": "Bearer Token, der ausgehend beim Verbinden mit der WebSocket-URL gesendet wird."
         }
       }
     }

--- a/custom_components/luxor_living/translations/en.json
+++ b/custom_components/luxor_living/translations/en.json
@@ -81,8 +81,8 @@
           "push_webhook": "Push Webhook",
           "push_ws_url": "WebSocket URL",
           "push_auth_method": "Authentication Method",
-          "push_token": "Token / Secret",
-          "push_ws_token": "WebSocket Bearer Token"
+          "push_token": "Incoming Token / HMAC Secret",
+          "push_ws_token": "Outgoing WebSocket Bearer Token"
         },
         "data_description": {
           "scan_interval": "How often to poll the gateway for state updates (5–300 seconds). With Push Webhook active, 60–120 s is sufficient.",
@@ -93,8 +93,8 @@
           "push_webhook": "Optional: receive real-time KNX state updates from an external forwarder instead of relying solely on polling.",
           "push_ws_url": "WebSocket URL of an external KNX forwarder (e.g. ws://192.168.1.100:8765). Leave empty to disable.",
           "push_auth_method": "Authentication method for incoming push HTTP requests: none, token, bearer, or hmac.",
-          "push_token": "Shared secret for token / hmac authentication.",
-          "push_ws_token": "Bearer token sent when connecting to the WebSocket URL."
+          "push_token": "Shared secret verified on incoming push requests (token / hmac auth).",
+          "push_ws_token": "Bearer token sent outbound when connecting to the WebSocket URL."
         }
       }
     }


### PR DESCRIPTION
UI/UX improvements to the config flow and options form.

## Changes

**Security fix**
- Password field in gateway setup was `str` (plain text visible) → now `TextSelector(PASSWORD)`
- Reauth password field → `TextSelector(PASSWORD)`

**Routing mode cleanup**
- When "Routing (KNX/IP)" is selected, username and password fields are no longer shown (they are unused for routing)

**Reauth UX**
- Username is pre-filled from the stored config entry — user only needs to re-enter the password

**Options form**
- `log_level`: was `vol.In([...])` rendering as a free-text input → now `SelectSelector` with proper labels
- `scan_interval`: was raw number input → `NumberSelector` with slider, min=5, max=300, unit=s
- `discovery_timeout`: was raw float input → `NumberSelector` with min=0.5, max=10.0, step=0.5, unit=s

**Translation labels**
- `push_token` → "Incoming Token / HMAC Secret" (clarifies direction)
- `push_ws_token` → "Outgoing WebSocket Bearer Token" (clarifies direction)