### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: philsmith91

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Report a problem with the LUXORliving integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill in as much detail as possible. Incomplete reports are harder to debug.
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration Version
+      description:
+        Found in Settings → Devices & Services → LUXORliving → version
+      placeholder: "e.g. v1.1.12"
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Version
+      description: Found in Settings → About
+      placeholder: "e.g. 2026.4.3"
+    validations:
+      required: true
+
+  - type: input
+    id: ip1_firmware
+    attributes:
+      label: IP1 Firmware Version
+      description: Found in the LUXORliving IP1 web interface
+      placeholder: "e.g. 1.3.2"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Messages
+      description: |
+        Enable debug logging first: Settings → Devices & Services → LUXORliving → Enable debug logging.
+        Then reproduce the issue and paste relevant log lines here.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Additional Context
+      description:
+        Anything else that might be relevant (number of KNX groups, special
+        device types, network setup, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,36 +1,87 @@
 name: Feature Request
-description: Suggest a new feature or improvement
+description:
+  Suggest a new feature or improvement for the LUXORliving integration
 labels: ["enhancement"]
 body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the integration does this involve?
+      options:
+        - "Entity platform (Light / Switch / Climate / Cover / Sensor)"
+        - "LXP import / entity mapping"
+        - "Config Flow / Options Flow"
+        - "REST client / BAOS API communication"
+        - "KNX Gateway / protocol"
+        - "Coordinator / polling"
+        - "Diagnostics / logging"
+        - "Other"
+    validations:
+      required: true
+
+  - type: input
+    id: device_type
+    attributes:
+      label: LUXORliving Device / Function Type
+      description: Which Theben device or KNX function type is this about?
+      placeholder:
+        "e.g. R718 thermostat, dimmer actuator, shutter, binary input…"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: api_support
+    attributes:
+      label: Is this exposed by the IP1 REST API (BAOS)?
+      description:
+        Check the IP1 web interface or Theben docs — if the data point isn't
+        available via REST, it cannot be implemented without major changes.
+      options:
+        - "Yes — visible in the IP1 web interface / BAOS"
+        - "No / not sure"
+        - "Unknown"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: lxp_support
+    attributes:
+      label: Is this represented in the LXP export?
+      description:
+        Open your LXP file and check if this device or function type appears.
+        Required for automatic entity mapping.
+      options:
+        - "Yes — present in LXP export"
+        - "No — not in LXP"
+        - "Unknown"
+    validations:
+      required: false
+
+  - type: input
+    id: ip1_firmware
+    attributes:
+      label: IP1 Firmware Version
+      description:
+        Some features require a specific IP1 firmware. Found in the IP1 web
+        interface.
+      placeholder: "e.g. 1.3.2"
+    validations:
+      required: false
+
   - type: textarea
     id: problem
     attributes:
       label: What problem does this solve?
-      description: Describe the use case or limitation you're running into.
+      description:
+        What can't you do today? What workaround are you currently using?
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: Proposed Solution
-      description: What should the integration do differently?
+      label: Proposed Behavior
+      description: How should the integration behave after this is implemented?
     validations:
       required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives Considered
-      description: Any workarounds or other approaches you've tried?
-    validations:
-      required: false
-
-  - type: input
-    id: device
-    attributes:
-      label: Affected Device / Function Type
-      description: e.g. R718 climate, dimmer, shutter, sensor…
-      placeholder: "e.g. R718 thermostat"
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or limitation you're running into.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: What should the integration do differently?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any workarounds or other approaches you've tried?
+    validations:
+      required: false
+
+  - type: input
+    id: device
+    attributes:
+      label: Affected Device / Function Type
+      description: e.g. R718 climate, dimmer, shutter, sensor…
+      placeholder: "e.g. R718 thermostat"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,40 @@
 ## Summary
 
-<!-- What does this PR do and why? -->
+<!-- What does this PR do and why? Which component/layer is affected? -->
 
 ## Type of Change
 
 - [ ] Bug fix
-- [ ] New feature / device support
+- [ ] New entity platform or device support
+- [ ] LXP parser / entity mapper change
+- [ ] Config Flow / Options Flow change
+- [ ] REST client / BAOS API change
+- [ ] KNX protocol change
 - [ ] Refactoring / code quality
-- [ ] Documentation
-- [ ] CI / tooling
+- [ ] Documentation / CI
 
 ## Checklist
 
+**Required for every PR:**
+
 - [ ] `pre-commit run --all-files` passes (black, isort, flake8, bandit,
       prettier)
-- [ ] `python -m pytest tests/ -v -m "not enable_socket"` passes
-- [ ] New tests added for new behavior
-- [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] `python -m pytest tests/ -v -m "not enable_socket"` — all tests pass
+- [ ] `./scripts/validate_readme.sh` passes
+- [ ] New behavior covered by tests
+- [ ] Type hints on all new public functions
+
+**If user-facing change:**
+
+- [ ] `CHANGELOG.md` updated
+- [ ] README.md test count updated
+
+**If new device / entity type:**
+
+- [ ] Simulation mode works without hardware
+- [ ] LXP parser handles the new type
+
+**If touching BAOS REST API or KNX protocol:**
+
+- [ ] Tested on real hardware (IP1 + HA) — strongly recommended
+- [ ] `./scripts/check_release_notes.sh` passes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature / device support
+- [ ] Refactoring / code quality
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] `pre-commit run --all-files` passes (black, isort, flake8, bandit,
+      prettier)
+- [ ] `python -m pytest tests/ -v -m "not enable_socket"` passes
+- [ ] New tests added for new behavior
+- [ ] CHANGELOG.md updated (if user-facing change)


### PR DESCRIPTION
## Summary
- Adds Bug Report template with fields for integration version, HA version, IP1 firmware, steps to reproduce, and debug logs
- Adds Feature Request template with use case, proposed solution, and affected device type

## Why
Structured issue templates reduce back-and-forth with users — especially useful given the active HACS user base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)