### PR TITLE
fix: require auth on push endpoint and health view

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: philsmith91

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Report a problem with the LUXORliving integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill in as much detail as possible. Incomplete reports are harder to debug.
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration Version
+      description:
+        Found in Settings → Devices & Services → LUXORliving → version
+      placeholder: "e.g. v1.1.12"
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Version
+      description: Found in Settings → About
+      placeholder: "e.g. 2026.4.3"
+    validations:
+      required: true
+
+  - type: input
+    id: ip1_firmware
+    attributes:
+      label: IP1 Firmware Version
+      description: Found in the LUXORliving IP1 web interface
+      placeholder: "e.g. 1.3.2"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Messages
+      description: |
+        Enable debug logging first: Settings → Devices & Services → LUXORliving → Enable debug logging.
+        Then reproduce the issue and paste relevant log lines here.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Additional Context
+      description:
+        Anything else that might be relevant (number of KNX groups, special
+        device types, network setup, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,36 +1,87 @@
 name: Feature Request
-description: Suggest a new feature or improvement
+description:
+  Suggest a new feature or improvement for the LUXORliving integration
 labels: ["enhancement"]
 body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the integration does this involve?
+      options:
+        - "Entity platform (Light / Switch / Climate / Cover / Sensor)"
+        - "LXP import / entity mapping"
+        - "Config Flow / Options Flow"
+        - "REST client / BAOS API communication"
+        - "KNX Gateway / protocol"
+        - "Coordinator / polling"
+        - "Diagnostics / logging"
+        - "Other"
+    validations:
+      required: true
+
+  - type: input
+    id: device_type
+    attributes:
+      label: LUXORliving Device / Function Type
+      description: Which Theben device or KNX function type is this about?
+      placeholder:
+        "e.g. R718 thermostat, dimmer actuator, shutter, binary input…"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: api_support
+    attributes:
+      label: Is this exposed by the IP1 REST API (BAOS)?
+      description:
+        Check the IP1 web interface or Theben docs — if the data point isn't
+        available via REST, it cannot be implemented without major changes.
+      options:
+        - "Yes — visible in the IP1 web interface / BAOS"
+        - "No / not sure"
+        - "Unknown"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: lxp_support
+    attributes:
+      label: Is this represented in the LXP export?
+      description:
+        Open your LXP file and check if this device or function type appears.
+        Required for automatic entity mapping.
+      options:
+        - "Yes — present in LXP export"
+        - "No — not in LXP"
+        - "Unknown"
+    validations:
+      required: false
+
+  - type: input
+    id: ip1_firmware
+    attributes:
+      label: IP1 Firmware Version
+      description:
+        Some features require a specific IP1 firmware. Found in the IP1 web
+        interface.
+      placeholder: "e.g. 1.3.2"
+    validations:
+      required: false
+
   - type: textarea
     id: problem
     attributes:
       label: What problem does this solve?
-      description: Describe the use case or limitation you're running into.
+      description:
+        What can't you do today? What workaround are you currently using?
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: Proposed Solution
-      description: What should the integration do differently?
+      label: Proposed Behavior
+      description: How should the integration behave after this is implemented?
     validations:
       required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives Considered
-      description: Any workarounds or other approaches you've tried?
-    validations:
-      required: false
-
-  - type: input
-    id: device
-    attributes:
-      label: Affected Device / Function Type
-      description: e.g. R718 climate, dimmer, shutter, sensor…
-      placeholder: "e.g. R718 thermostat"
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or limitation you're running into.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: What should the integration do differently?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any workarounds or other approaches you've tried?
+    validations:
+      required: false
+
+  - type: input
+    id: device
+    attributes:
+      label: Affected Device / Function Type
+      description: e.g. R718 climate, dimmer, shutter, sensor…
+      placeholder: "e.g. R718 thermostat"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,40 @@
 ## Summary
 
-<!-- What does this PR do and why? -->
+<!-- What does this PR do and why? Which component/layer is affected? -->
 
 ## Type of Change
 
 - [ ] Bug fix
-- [ ] New feature / device support
+- [ ] New entity platform or device support
+- [ ] LXP parser / entity mapper change
+- [ ] Config Flow / Options Flow change
+- [ ] REST client / BAOS API change
+- [ ] KNX protocol change
 - [ ] Refactoring / code quality
-- [ ] Documentation
-- [ ] CI / tooling
+- [ ] Documentation / CI
 
 ## Checklist
 
+**Required for every PR:**
+
 - [ ] `pre-commit run --all-files` passes (black, isort, flake8, bandit,
       prettier)
-- [ ] `python -m pytest tests/ -v -m "not enable_socket"` passes
-- [ ] New tests added for new behavior
-- [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] `python -m pytest tests/ -v -m "not enable_socket"` — all tests pass
+- [ ] `./scripts/validate_readme.sh` passes
+- [ ] New behavior covered by tests
+- [ ] Type hints on all new public functions
+
+**If user-facing change:**
+
+- [ ] `CHANGELOG.md` updated
+- [ ] README.md test count updated
+
+**If new device / entity type:**
+
+- [ ] Simulation mode works without hardware
+- [ ] LXP parser handles the new type
+
+**If touching BAOS REST API or KNX protocol:**
+
+- [ ] Tested on real hardware (IP1 + HA) — strongly recommended
+- [ ] `./scripts/check_release_notes.sh` passes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature / device support
+- [ ] Refactoring / code quality
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] `pre-commit run --all-files` passes (black, isort, flake8, bandit,
+      prettier)
+- [ ] `python -m pytest tests/ -v -m "not enable_socket"` passes
+- [ ] New tests added for new behavior
+- [ ] CHANGELOG.md updated (if user-facing change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the LUXORliving Home Assistant integration will be
 documented in this file.
 
+## [1.1.13] - 2026-06-07
+
+### Security
+
+- **Push endpoint now requires authentication (CVE-style fix)**: The
+  `/api/luxor_living/push` endpoint previously defaulted to unauthenticated
+  access (`auth_method = none`), allowing any host that could reach the HA HTTP
+  port to write arbitrary values to KNX group addresses (lights, covers, etc.).
+  The `none` auth option is removed. All requests without valid credentials now
+  return `403`. Token and Bearer auth methods additionally reject if no token is
+  configured (previously silently accepted all requests).
+
+- **Health view now requires HA authentication**: `/api/luxor_living/health`
+  now sets `requires_auth = True` and requires a valid HA long-lived access
+  token. Previously exposed topology information (entry IDs, KNX address counts,
+  simulation mode, circuit breaker state) without authentication.
+
+### Changed
+
+- Push webhook config: `None` auth option removed from Options Flow. Existing
+  installations with `auth_method = none` will have requests rejected until a
+  token and auth method are configured under Settings → Integrations →
+  LUXORliving → Configure.
+
 ## [1.1.12] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 990](https://img.shields.io/badge/Tests-990%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 992](https://img.shields.io/badge/Tests-992%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors, switches and binary sensors, all created without any manual YAML.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.1.12](https://github.com/phismith91/luxorliving/releases/tag/v1.1.12-rc.1) — Fix session race condition: asyncio.Lock prevents duplicate orphaned sessions that caused KNX bus freeze after ~47 h
+**Current release:** [v1.1.13](https://github.com/phismith91/luxorliving/releases/tag/v1.1.13) — Security fix: push endpoint and health view now require authentication
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -497,7 +497,7 @@ class LuxorLivingOptionsFlow(OptionsFlow):
 
         current_push_auth_method = self.config_entry.options.get(
             "push_auth_method",
-            self.config_entry.data.get("push_auth_method", "none"),
+            self.config_entry.data.get("push_auth_method", "token"),
         )
 
         current_allow_diagnostics = self.config_entry.options.get(
@@ -561,7 +561,6 @@ class LuxorLivingOptionsFlow(OptionsFlow):
                             ): selector.SelectSelector(
                                 selector.SelectSelectorConfig(
                                     options=[
-                                        selector.SelectOptionDict(value="none", label="None"),
                                         selector.SelectOptionDict(value="token", label="Token"),
                                         selector.SelectOptionDict(value="bearer", label="Bearer"),
                                         selector.SelectOptionDict(value="hmac", label="HMAC"),

--- a/custom_components/luxor_living/health_view.py
+++ b/custom_components/luxor_living/health_view.py
@@ -39,7 +39,7 @@ class LuxorLivingHealthView(HomeAssistantView):
 
     url = "/api/luxor_living/health"
     name = "api:luxor_living:health"
-    requires_auth = False  # Allow unauthenticated access for monitoring
+    requires_auth = True
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the health check view."""

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -17,7 +17,7 @@
     "xknx>=3.13.0",
     "defusedxml>=0.7.1"
   ],
-  "version": "1.1.12",
+  "version": "1.1.13",
   "zeroconf": [
     {
       "type": "_knxip._udp.local."

--- a/custom_components/luxor_living/push_view.py
+++ b/custom_components/luxor_living/push_view.py
@@ -78,7 +78,7 @@ class LuxorLivingPushView(HomeAssistantView):
         # Token-based (legacy): header X-LUXOR-PUSH-TOKEN must match
         if auth_method == "token":
             token_header = request.headers.get("X-LUXOR-PUSH-TOKEN")
-            if configured_token and token_header != configured_token:
+            if not configured_token or token_header != configured_token:
                 from aiohttp import web
 
                 return web.json_response({"error": "forbidden"}, status=403)
@@ -86,12 +86,8 @@ class LuxorLivingPushView(HomeAssistantView):
         # Bearer token: Authorization: Bearer <token>
         elif auth_method == "bearer":
             auth_header = request.headers.get("Authorization", "")
-            if configured_token and not auth_header.startswith("Bearer "):
-                from aiohttp import web
-
-                return web.json_response({"error": "forbidden"}, status=403)
-            bearer = auth_header.split(" ", 1)[1] if " " in auth_header else ""
-            if configured_token and bearer != configured_token:
+            bearer = auth_header.split(" ", 1)[1] if auth_header.startswith("Bearer ") else ""
+            if not configured_token or bearer != configured_token:
                 from aiohttp import web
 
                 return web.json_response({"error": "forbidden"}, status=403)
@@ -118,7 +114,11 @@ class LuxorLivingPushView(HomeAssistantView):
 
                 return web.json_response({"error": "forbidden"}, status=403)
 
-        # else: none -> accept unauthenticated pushes
+        # No valid auth method configured — always reject
+        else:
+            from aiohttp import web
+
+            return web.json_response({"error": "forbidden"}, status=403)
         # Handle push
         try:
             gateway = state.get_gateway_or_raise()

--- a/docs/releases/RELEASE_NOTES_v1.1.13.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.13.md
@@ -1,0 +1,28 @@
+# Release Notes — v1.1.13
+
+## Security
+
+- **Push endpoint now requires authentication**: The `/api/luxor_living/push`
+  endpoint previously defaulted to unauthenticated access (`auth_method = none`),
+  allowing any host that could reach the HA HTTP port to write arbitrary values to
+  KNX group addresses (lights, covers, actuators). The `none` auth option is
+  removed entirely. All requests without valid credentials now return `403`.
+  Token and Bearer auth methods additionally reject if no token is configured
+  (previously silently accepted all requests in that case).
+
+- **Health view now requires HA authentication**: `/api/luxor_living/health`
+  now sets `requires_auth = True` and requires a valid HA long-lived access token.
+  Previously exposed topology information (entry IDs, KNX address counts,
+  simulation mode, circuit breaker state) without authentication.
+
+## Changed
+
+- Push webhook Options Flow: `None` auth option removed. Existing installations
+  with `auth_method = none` will have push requests rejected until a token and
+  auth method are configured under Settings → Integrations → LUXORliving →
+  Configure.
+
+## Tests
+
+3 new security regression tests covering the previously-open attack surface.
+Test count: 990 → 992 (excluding socket-dependent tests).

--- a/tests/test_push_view.py
+++ b/tests/test_push_view.py
@@ -15,7 +15,7 @@ async def test_push_view_calls_gateway():
     # Prepare integration state and register
     entry = MagicMock()
     entry.entry_id = "test_entry_id"
-    entry.data = {}
+    entry.data = {"push_auth_method": "token", "push_token": "test-token"}
     entry.options = {}
 
     state = IntegrationState(mapper=MagicMock(), config={}, overrides={}, entry=entry)
@@ -36,7 +36,7 @@ async def test_push_view_calls_gateway():
     req.json = AsyncMock(
         return_value={"entry_id": entry.entry_id, "address": "1/2/3", "value": True}
     )
-    req.headers = {}
+    req.headers = {"X-LUXOR-PUSH-TOKEN": "test-token"}
 
     resp = await view.post(req)
 
@@ -155,11 +155,14 @@ async def test_push_view_hmac_auth():
 # ── Helper ────────────────────────────────────────────────────────────────────
 
 
+_DEFAULT_AUTH = {"push_auth_method": "token", "push_token": "test-token"}
+
+
 def _make_view(entry_data=None, entry_options=None, entry_id="test_entry"):
     """Return a (view, entry, gateway) triple wired for testing post()."""
     entry = MagicMock()
     entry.entry_id = entry_id
-    entry.data = entry_data or {}
+    entry.data = entry_data if entry_data is not None else dict(_DEFAULT_AUTH)
     entry.options = entry_options or {}
 
     from custom_components.luxor_living.integration_state import IntegrationState
@@ -183,7 +186,7 @@ def _make_view(entry_data=None, entry_options=None, entry_id="test_entry"):
 def _make_request(payload, headers=None):
     req = MagicMock()
     req.json = AsyncMock(return_value=payload)
-    req.headers = headers or {}
+    req.headers = headers if headers is not None else {"X-LUXOR-PUSH-TOKEN": "test-token"}
     return req
 
 
@@ -301,20 +304,53 @@ class TestPushViewMutationTargets:
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
-    async def test_no_auth_config_defaults_to_none_method(self):
-        """Kill mutmut_90: 'none' → 'NONE' fallback.
+    async def test_no_auth_method_configured_returns_403(self):
+        """Push endpoint must reject requests when no auth method is configured.
 
-        When no push_auth_method is configured the endpoint must accept
-        unauthenticated requests.
+        Security requirement: unauthenticated access is never permitted.
+        An entry with no push_auth_method must not allow arbitrary KNX writes.
         """
-        view, entry, gateway = _make_view()  # no auth configured
+        view, entry, gateway = _make_view(entry_data={})
 
         resp = await view.post(
-            _make_request({"entry_id": entry.entry_id, "address": "1/2/3", "value": True})
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={},
+            )
         )
 
-        assert resp.status == 200
-        gateway.process_incoming_value.assert_awaited_once()
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_token_auth_without_configured_token_returns_403(self):
+        """Token auth with no token stored must reject, not allow all requests."""
+        view, entry, gateway = _make_view(entry_data={"push_auth_method": "token"})
+
+        resp = await view.post(
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={"X-LUXOR-PUSH-TOKEN": "anything"},
+            )
+        )
+
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bearer_auth_without_configured_token_returns_403(self):
+        """Bearer auth with no token stored must reject, not allow all requests."""
+        view, entry, gateway = _make_view(entry_data={"push_auth_method": "bearer"})
+
+        resp = await view.post(
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={"Authorization": "Bearer anything"},
+            )
+        )
+
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Addresses security review feedback from @frenck for HA integration catalog submission.

- **push endpoint**: `auth_method="none"` and token/bearer auth without a configured token now return `403` instead of accepting unauthenticated requests. The unauthenticated fallback is removed entirely.
- **health view**: `requires_auth = True` — HA long-lived access token required
- **config flow**: removed `None` auth option, default changed to `Token`
- **tests**: `_make_view`/`_make_request` now default to token auth; three new tests cover the previously-open attack surface

## Security impact

Before: any host that could reach the HA HTTP port could POST to `/api/luxor_living/push` and write arbitrary values to KNX group addresses (controlling lights, covers, etc.) if no auth method was explicitly configured.

After: all requests without valid credentials are rejected with `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)