### PR TITLE
fix: require auth on push endpoint and health view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the LUXORliving Home Assistant integration will be
 documented in this file.
 
+## [1.1.13] - 2026-06-07
+
+### Security
+
+- **Push endpoint now requires authentication (CVE-style fix)**: The
+  `/api/luxor_living/push` endpoint previously defaulted to unauthenticated
+  access (`auth_method = none`), allowing any host that could reach the HA HTTP
+  port to write arbitrary values to KNX group addresses (lights, covers, etc.).
+  The `none` auth option is removed. All requests without valid credentials now
+  return `403`. Token and Bearer auth methods additionally reject if no token is
+  configured (previously silently accepted all requests).
+
+- **Health view now requires HA authentication**: `/api/luxor_living/health`
+  now sets `requires_auth = True` and requires a valid HA long-lived access
+  token. Previously exposed topology information (entry IDs, KNX address counts,
+  simulation mode, circuit breaker state) without authentication.
+
+### Changed
+
+- Push webhook config: `None` auth option removed from Options Flow. Existing
+  installations with `auth_method = none` will have requests rejected until a
+  token and auth method are configured under Settings → Integrations →
+  LUXORliving → Configure.
+
 ## [1.1.12] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 990](https://img.shields.io/badge/Tests-990%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 992](https://img.shields.io/badge/Tests-992%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors, switches and binary sensors, all created without any manual YAML.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.1.12](https://github.com/phismith91/luxorliving/releases/tag/v1.1.12-rc.1) — Fix session race condition: asyncio.Lock prevents duplicate orphaned sessions that caused KNX bus freeze after ~47 h
+**Current release:** [v1.1.13](https://github.com/phismith91/luxorliving/releases/tag/v1.1.13) — Security fix: push endpoint and health view now require authentication
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -497,7 +497,7 @@ class LuxorLivingOptionsFlow(OptionsFlow):
 
         current_push_auth_method = self.config_entry.options.get(
             "push_auth_method",
-            self.config_entry.data.get("push_auth_method", "none"),
+            self.config_entry.data.get("push_auth_method", "token"),
         )
 
         current_allow_diagnostics = self.config_entry.options.get(
@@ -561,7 +561,6 @@ class LuxorLivingOptionsFlow(OptionsFlow):
                             ): selector.SelectSelector(
                                 selector.SelectSelectorConfig(
                                     options=[
-                                        selector.SelectOptionDict(value="none", label="None"),
                                         selector.SelectOptionDict(value="token", label="Token"),
                                         selector.SelectOptionDict(value="bearer", label="Bearer"),
                                         selector.SelectOptionDict(value="hmac", label="HMAC"),

--- a/custom_components/luxor_living/health_view.py
+++ b/custom_components/luxor_living/health_view.py
@@ -39,7 +39,7 @@ class LuxorLivingHealthView(HomeAssistantView):
 
     url = "/api/luxor_living/health"
     name = "api:luxor_living:health"
-    requires_auth = False  # Allow unauthenticated access for monitoring
+    requires_auth = True
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the health check view."""

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -17,7 +17,7 @@
     "xknx>=3.13.0",
     "defusedxml>=0.7.1"
   ],
-  "version": "1.1.12",
+  "version": "1.1.13",
   "zeroconf": [
     {
       "type": "_knxip._udp.local."

--- a/custom_components/luxor_living/push_view.py
+++ b/custom_components/luxor_living/push_view.py
@@ -78,7 +78,7 @@ class LuxorLivingPushView(HomeAssistantView):
         # Token-based (legacy): header X-LUXOR-PUSH-TOKEN must match
         if auth_method == "token":
             token_header = request.headers.get("X-LUXOR-PUSH-TOKEN")
-            if configured_token and token_header != configured_token:
+            if not configured_token or token_header != configured_token:
                 from aiohttp import web
 
                 return web.json_response({"error": "forbidden"}, status=403)
@@ -86,12 +86,8 @@ class LuxorLivingPushView(HomeAssistantView):
         # Bearer token: Authorization: Bearer <token>
         elif auth_method == "bearer":
             auth_header = request.headers.get("Authorization", "")
-            if configured_token and not auth_header.startswith("Bearer "):
-                from aiohttp import web
-
-                return web.json_response({"error": "forbidden"}, status=403)
-            bearer = auth_header.split(" ", 1)[1] if " " in auth_header else ""
-            if configured_token and bearer != configured_token:
+            bearer = auth_header.split(" ", 1)[1] if auth_header.startswith("Bearer ") else ""
+            if not configured_token or bearer != configured_token:
                 from aiohttp import web
 
                 return web.json_response({"error": "forbidden"}, status=403)
@@ -118,7 +114,11 @@ class LuxorLivingPushView(HomeAssistantView):
 
                 return web.json_response({"error": "forbidden"}, status=403)
 
-        # else: none -> accept unauthenticated pushes
+        # No valid auth method configured — always reject
+        else:
+            from aiohttp import web
+
+            return web.json_response({"error": "forbidden"}, status=403)
         # Handle push
         try:
             gateway = state.get_gateway_or_raise()

--- a/docs/releases/RELEASE_NOTES_v1.1.13.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.13.md
@@ -1,0 +1,28 @@
+# Release Notes — v1.1.13
+
+## Security
+
+- **Push endpoint now requires authentication**: The `/api/luxor_living/push`
+  endpoint previously defaulted to unauthenticated access (`auth_method = none`),
+  allowing any host that could reach the HA HTTP port to write arbitrary values to
+  KNX group addresses (lights, covers, actuators). The `none` auth option is
+  removed entirely. All requests without valid credentials now return `403`.
+  Token and Bearer auth methods additionally reject if no token is configured
+  (previously silently accepted all requests in that case).
+
+- **Health view now requires HA authentication**: `/api/luxor_living/health`
+  now sets `requires_auth = True` and requires a valid HA long-lived access token.
+  Previously exposed topology information (entry IDs, KNX address counts,
+  simulation mode, circuit breaker state) without authentication.
+
+## Changed
+
+- Push webhook Options Flow: `None` auth option removed. Existing installations
+  with `auth_method = none` will have push requests rejected until a token and
+  auth method are configured under Settings → Integrations → LUXORliving →
+  Configure.
+
+## Tests
+
+3 new security regression tests covering the previously-open attack surface.
+Test count: 990 → 992 (excluding socket-dependent tests).

--- a/tests/test_push_view.py
+++ b/tests/test_push_view.py
@@ -15,7 +15,7 @@ async def test_push_view_calls_gateway():
     # Prepare integration state and register
     entry = MagicMock()
     entry.entry_id = "test_entry_id"
-    entry.data = {}
+    entry.data = {"push_auth_method": "token", "push_token": "test-token"}
     entry.options = {}
 
     state = IntegrationState(mapper=MagicMock(), config={}, overrides={}, entry=entry)
@@ -36,7 +36,7 @@ async def test_push_view_calls_gateway():
     req.json = AsyncMock(
         return_value={"entry_id": entry.entry_id, "address": "1/2/3", "value": True}
     )
-    req.headers = {}
+    req.headers = {"X-LUXOR-PUSH-TOKEN": "test-token"}
 
     resp = await view.post(req)
 
@@ -155,11 +155,14 @@ async def test_push_view_hmac_auth():
 # ── Helper ────────────────────────────────────────────────────────────────────
 
 
+_DEFAULT_AUTH = {"push_auth_method": "token", "push_token": "test-token"}
+
+
 def _make_view(entry_data=None, entry_options=None, entry_id="test_entry"):
     """Return a (view, entry, gateway) triple wired for testing post()."""
     entry = MagicMock()
     entry.entry_id = entry_id
-    entry.data = entry_data or {}
+    entry.data = entry_data if entry_data is not None else dict(_DEFAULT_AUTH)
     entry.options = entry_options or {}
 
     from custom_components.luxor_living.integration_state import IntegrationState
@@ -183,7 +186,7 @@ def _make_view(entry_data=None, entry_options=None, entry_id="test_entry"):
 def _make_request(payload, headers=None):
     req = MagicMock()
     req.json = AsyncMock(return_value=payload)
-    req.headers = headers or {}
+    req.headers = headers if headers is not None else {"X-LUXOR-PUSH-TOKEN": "test-token"}
     return req
 
 
@@ -301,20 +304,53 @@ class TestPushViewMutationTargets:
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
-    async def test_no_auth_config_defaults_to_none_method(self):
-        """Kill mutmut_90: 'none' → 'NONE' fallback.
+    async def test_no_auth_method_configured_returns_403(self):
+        """Push endpoint must reject requests when no auth method is configured.
 
-        When no push_auth_method is configured the endpoint must accept
-        unauthenticated requests.
+        Security requirement: unauthenticated access is never permitted.
+        An entry with no push_auth_method must not allow arbitrary KNX writes.
         """
-        view, entry, gateway = _make_view()  # no auth configured
+        view, entry, gateway = _make_view(entry_data={})
 
         resp = await view.post(
-            _make_request({"entry_id": entry.entry_id, "address": "1/2/3", "value": True})
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={},
+            )
         )
 
-        assert resp.status == 200
-        gateway.process_incoming_value.assert_awaited_once()
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_token_auth_without_configured_token_returns_403(self):
+        """Token auth with no token stored must reject, not allow all requests."""
+        view, entry, gateway = _make_view(entry_data={"push_auth_method": "token"})
+
+        resp = await view.post(
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={"X-LUXOR-PUSH-TOKEN": "anything"},
+            )
+        )
+
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bearer_auth_without_configured_token_returns_403(self):
+        """Bearer auth with no token stored must reject, not allow all requests."""
+        view, entry, gateway = _make_view(entry_data={"push_auth_method": "bearer"})
+
+        resp = await view.post(
+            _make_request(
+                {"entry_id": entry.entry_id, "address": "1/2/3", "value": True},
+                headers={"Authorization": "Bearer anything"},
+            )
+        )
+
+        assert resp.status == 403
+        gateway.process_incoming_value.assert_not_called()
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Addresses security review feedback from @frenck for HA integration catalog submission ([hacs/default#6488](https://github.com/hacs/default/pull/6488)).

- **push endpoint**: `auth_method="none"` and token/bearer auth without a configured token now return `403` instead of accepting unauthenticated requests. The unauthenticated fallback is removed entirely.
- **health view**: `requires_auth = True` — HA long-lived access token required
- **config flow**: removed `None` auth option, default changed to `Token`
- **tests**: `_make_view`/`_make_request` now default to token auth; three new tests cover the previously-open attack surface

## Security impact

Before: any host that could reach the HA HTTP port could POST to `/api/luxor_living/push` and write arbitrary values to KNX group addresses (controlling lights, covers, etc.) if no auth method was explicitly configured.

After: all requests without valid credentials are rejected with `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)