### PR TITLE
ci: fix dependabot validation workflow — bump Python 3.13 → 3.14

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Cache pip dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- `homeassistant>=2026.4.4` requires Python >=3.14.2 on PyPI
- All HA releases from 2026.3.0 onward are only published for Python 3.14+
- Dependabot validation job was still pinned to 3.13, causing install failure

## Root cause

```
ERROR: No matching distribution found for homeassistant>=2026.4.4; extra == "dev"
```

pip on Python 3.13 found no compatible HA version since every recent release is Python 3.14+ only.

## Fix

One-line change: `python-version: "3.13"` → `"3.14"` in `.github/workflows/dependabot.yml`

All other workflows already use 3.14 — only this one was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)