### PR TITLE
feat(quality-scale): Gold stale-device removal + Platinum websession injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the LUXORliving Home Assistant integration will be
 documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Gold quality scale — stale-device handling**: implemented
+  `async_remove_config_entry_device`. Devices that disappeared from the LXP
+  project (no longer mapped by the integration) can now be deleted manually from
+  the HA UI, while the gateway hub and active devices remain protected.
+
+### Changed
+
+- **Platinum quality scale — inject websession**: the REST client
+  (`BAOSRestClient`) and the WebSocket `PushClient` now obtain their aiohttp
+  session from Home Assistant's shared `async_get_clientsession(hass)` instead of
+  creating and owning their own `ClientSession`. The REST client accepts an
+  injected session (`verify_ssl=False` for the IP1's self-signed cert) and only
+  closes sessions it owns; the push client no longer closes the shared session.
+
 ## [1.1.15] - 2026-06-13
 
 Pre-release (`v1.1.15-rc.1`). Bundles the post-1.1.14 security, entity, and hygiene fixes plus a

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 975](https://img.shields.io/badge/Tests-975%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 984](https://img.shields.io/badge/Tests-984%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors and binary sensors, all created without any manual YAML.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 984](https://img.shields.io/badge/Tests-984%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 986](https://img.shields.io/badge/Tests-986%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/__init__.py
+++ b/custom_components/luxor_living/__init__.py
@@ -356,3 +356,33 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Error stopping push client during unload: %s", err)
 
     return bool(unload_ok)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Allow manual deletion of a device that the integration no longer provides.
+
+    A device is considered *current* when one of its identifiers matches either
+    the gateway hub (``(DOMAIN, entry_id)``) or a ``device_id`` still present in
+    the active entity mapping. Devices that disappeared from the LXP project
+    (stale devices) carry no matching identifier and may be removed by the user;
+    current devices are protected. When the entry has no runtime data (already
+    torn down) every device is treated as stale.
+    """
+    current_ids: set[str] = {config_entry.entry_id}
+
+    runtime_data = getattr(config_entry, "runtime_data", None)
+    mapper = getattr(runtime_data, "mapper", None)
+    if mapper is not None:
+        for mapped_entity in mapper.entities:
+            device_id = getattr(mapped_entity, "device_id", None)
+            if device_id:
+                current_ids.add(device_id)
+
+    return not any(
+        domain == DOMAIN and identifier in current_ids
+        for domain, identifier in device_entry.identifiers
+    )

--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_ALLOW_DIAGNOSTICS,
@@ -438,7 +439,8 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         _LOGGER.debug("🔐 Validating credentials for %s@%s", username, host)
 
-        async with BAOSRestClient(host, port=DEFAULT_HTTP_PORT) as client:
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        async with BAOSRestClient(host, port=DEFAULT_HTTP_PORT, session=session) as client:
             # Attempt login - will raise AuthenticationError if invalid
             await client.login(username, password)
             _LOGGER.debug("Credentials validated successfully")

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any, Callable, cast
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from xknx import XKNX
 from xknx.core import XknxConnectionState
 from xknx.dpt import DPTArray, DPTBinary
@@ -142,7 +143,8 @@ class LuxorKNXGateway:
                 _LOGGER.debug("Step 1/3: REST API Login...")
 
                 # Create REST client and enter async context
-                self._rest_client = BAOSRestClient(self.host, port=self.http_port)
+                session = async_get_clientsession(self.hass, verify_ssl=False)
+                self._rest_client = BAOSRestClient(self.host, port=self.http_port, session=session)
                 await self._rest_client.__aenter__()
 
                 try:

--- a/custom_components/luxor_living/push_client.py
+++ b/custom_components/luxor_living/push_client.py
@@ -22,6 +22,7 @@ import json
 import logging
 
 from aiohttp import ClientSession, ClientWebSocketResponse
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +47,11 @@ class PushClient:
         self._task = self.hass.async_create_task(self._run())
 
     async def stop(self) -> None:
-        """Stop the client and cancel background task."""
+        """Stop the client and cancel background task.
+
+        The aiohttp session is owned by Home Assistant (shared via
+        ``async_get_clientsession``) so it is intentionally not closed here.
+        """
         self._stopped = True
         if self._task and not self._task.done():
             self._task.cancel()
@@ -54,16 +59,12 @@ class PushClient:
                 await self._task
             except asyncio.CancelledError:
                 pass
-        if self._session:
-            try:
-                await self._session.close()
-            except Exception as err:
-                _LOGGER.debug("Error closing push client session: %s", err)
+        self._session = None
 
     async def _run(self) -> None:
         """Run connection loop with exponential backoff."""
         backoff = 1.0
-        self._session = ClientSession()
+        self._session = async_get_clientsession(self.hass)
 
         while not self._stopped:
             try:

--- a/custom_components/luxor_living/repairs.py
+++ b/custom_components/luxor_living/repairs.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 from .rest_client import AuthenticationError, BAOSRestClient
@@ -62,7 +63,8 @@ class LuxorLivingAuthenticationRepairFlow(RepairsFlow):
             password = user_input[CONF_PASSWORD]
 
             try:
-                async with BAOSRestClient(host, use_https=True) as client:
+                session = async_get_clientsession(self.hass, verify_ssl=False)
+                async with BAOSRestClient(host, use_https=True, session=session) as client:
                     await client.login(username, password)
                     _LOGGER.info("Authentication repair successful for %s", host)
 

--- a/custom_components/luxor_living/rest_client.py
+++ b/custom_components/luxor_living/rest_client.py
@@ -56,7 +56,13 @@ class BAOSRestClient:
     - PUT /rest/device/authtunneling → Enable/Disable Tunneling
     """
 
-    def __init__(self, host: str, port: int = 443, use_https: bool = True):
+    def __init__(
+        self,
+        host: str,
+        port: int = 443,
+        use_https: bool = True,
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
         """
         Initialize REST API Client.
 
@@ -64,6 +70,10 @@ class BAOSRestClient:
             host: IP address of BAOS 777 device
             port: Port for REST API (default: 443 for HTTPS)
             use_https: Use HTTPS for secure communication (default: True, recommended)
+            session: Optional aiohttp session to use. When provided (e.g. Home
+                Assistant's shared ``async_get_clientsession``), the client uses
+                it and never closes it. When omitted, the client lazily creates
+                and owns its own session.
         """
         self.host = host
         self.port = port
@@ -76,22 +86,26 @@ class BAOSRestClient:
         self.session_expires: Optional[datetime] = None
         self.tunneling_enabled = False
 
-        self._session: Optional[aiohttp.ClientSession] = None
+        self._session: Optional[aiohttp.ClientSession] = session
+        self._owns_session = session is None
+        self._timeout = aiohttp.ClientTimeout(total=30)
 
     async def __aenter__(self):
         """Context manager entry."""
-        loop = asyncio.get_running_loop()
-        ssl_context = await loop.run_in_executor(None, _make_ssl_context)
-        connector = aiohttp.TCPConnector(ssl=ssl_context)
-        self._session = aiohttp.ClientSession(
-            connector=connector, connector_owner=True, timeout=aiohttp.ClientTimeout(total=30)
-        )
+        if self._owns_session and self._session is None:
+            loop = asyncio.get_running_loop()
+            ssl_context = await loop.run_in_executor(None, _make_ssl_context)
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self._session = aiohttp.ClientSession(
+                connector=connector, connector_owner=True, timeout=self._timeout
+            )
         return self
 
     async def __aexit__(self, *args):
         """Context manager exit - ensures cleanup."""
         await self.logout()
-        if self._session:
+        # Only close sessions we own; injected (shared) sessions belong to HA.
+        if self._owns_session and self._session:
             await self._session.close()
 
     async def login(self, username: str, password: str) -> str:
@@ -108,12 +122,12 @@ class BAOSRestClient:
         Raises:
             AuthenticationError: If login fails
         """
-        if not self._session:
+        if not self._session and self._owns_session:
             loop = asyncio.get_running_loop()
             ssl_context = await loop.run_in_executor(None, _make_ssl_context)
             connector = aiohttp.TCPConnector(ssl=ssl_context)
             self._session = aiohttp.ClientSession(
-                connector=connector, connector_owner=True, timeout=aiohttp.ClientTimeout(total=30)
+                connector=connector, connector_owner=True, timeout=self._timeout
             )
 
         url = f"{self.base_url}/rest/login"
@@ -122,7 +136,7 @@ class BAOSRestClient:
         _LOGGER.debug(f"Attempting login to {url} with user: {username}")
 
         try:
-            async with self._session.post(url, json=payload) as response:
+            async with self._session.post(url, json=payload, timeout=self._timeout) as response:
                 _LOGGER.debug(f"Login response status: {response.status}")
                 _LOGGER.debug(f"Login response headers: {response.headers}")
 
@@ -177,7 +191,7 @@ class BAOSRestClient:
         _LOGGER.debug(f"Logging out from {url}")
 
         try:
-            async with self._session.post(url, headers=headers) as response:
+            async with self._session.post(url, headers=headers, timeout=self._timeout) as response:
                 if response.status in (200, 204):  # API returns 204 per docs
                     _LOGGER.info("Logout successful. Tunneling auto-deactivated.")
                 else:
@@ -223,7 +237,9 @@ class BAOSRestClient:
                 "set" if self.session_token else "missing",
             )
 
-            async with self._session.put(url, json=payload, headers=headers) as response:
+            async with self._session.put(
+                url, json=payload, headers=headers, timeout=self._timeout
+            ) as response:
                 _LOGGER.debug(f"Tunneling response status: {response.status}")
                 _LOGGER.debug(f"Tunneling response headers: {response.headers}")
 
@@ -282,7 +298,9 @@ class BAOSRestClient:
 
             _LOGGER.debug(f"Disabling tunneling at {url}")
 
-            async with self._session.put(url, json=payload, headers=headers) as response:
+            async with self._session.put(
+                url, json=payload, headers=headers, timeout=self._timeout
+            ) as response:
                 if response.status in (200, 204):
                     self.tunneling_enabled = False
                     _LOGGER.info(f"KNX Tunneling disabled ({response.status})")
@@ -318,7 +336,7 @@ class BAOSRestClient:
         url = f"{self.base_url}/rest/device/authtunneling"
         headers = self._get_auth_headers()
 
-        async with self._session.get(url, headers=headers) as response:
+        async with self._session.get(url, headers=headers, timeout=self._timeout) as response:
             if response.status == 200:
                 return cast(Dict[str, Any], await response.json())
             else:
@@ -358,7 +376,7 @@ class BAOSRestClient:
         _LOGGER.debug(f"🔍 Fetching all datapoints from {url}")
 
         try:
-            async with self._session.get(url, headers=headers) as response:
+            async with self._session.get(url, headers=headers, timeout=self._timeout) as response:
                 if response.status == 401:
                     _LOGGER.error("Session expired when fetching datapoints")
                     return None

--- a/tests/test_inject_websession.py
+++ b/tests/test_inject_websession.py
@@ -1,0 +1,78 @@
+"""Tests for Platinum inject-websession compliance.
+
+Both the REST client and the push client must obtain their aiohttp session from
+Home Assistant's shared `async_get_clientsession(hass)` helper instead of
+creating (and owning) their own `ClientSession`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import custom_components.luxor_living.push_client as push_client_mod
+from custom_components.luxor_living.push_client import PushClient
+from custom_components.luxor_living.rest_client import BAOSRestClient
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_push_run_acquires_shared_session(monkeypatch):
+    """PushClient._run obtains the session from async_get_clientsession(hass)."""
+    shared = MagicMock()
+    captured = {}
+
+    def fake_get_clientsession(hass):
+        captured["hass"] = hass
+        return shared
+
+    monkeypatch.setattr(push_client_mod, "async_get_clientsession", fake_get_clientsession)
+
+    client = PushClient(MagicMock(), "entry", "ws://example/ws")
+    client._stopped = True  # skip the connect loop body, only acquire session
+    await client._run()
+
+    assert client._session is shared
+    assert captured["hass"] is client.hass
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_push_stop_does_not_close_shared_session():
+    """PushClient.stop must not close the HA-owned shared session."""
+    shared = MagicMock()
+    shared.close = AsyncMock()
+
+    client = PushClient(MagicMock(), "entry", "ws://example/ws")
+    client._session = shared
+    await client.stop()
+
+    shared.close.assert_not_called()
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_rest_client_uses_injected_session():
+    """BAOSRestClient accepts an injected session and treats it as not-owned."""
+    shared = MagicMock()
+    shared.close = AsyncMock()
+
+    client = BAOSRestClient("1.2.3.4", session=shared)
+    assert client._session is shared
+
+    # Context-manager entry must not replace an injected session.
+    await client.__aenter__()
+    assert client._session is shared
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_rest_client_does_not_close_injected_session():
+    """Exiting the context manager must not close an injected (shared) session."""
+    shared = MagicMock()
+    shared.close = AsyncMock()
+
+    client = BAOSRestClient("1.2.3.4", session=shared)
+    client.logout = AsyncMock()
+    await client.__aexit__(None, None, None)
+
+    shared.close.assert_not_called()

--- a/tests/test_inject_websession.py
+++ b/tests/test_inject_websession.py
@@ -76,3 +76,22 @@ async def test_rest_client_does_not_close_injected_session():
     await client.__aexit__(None, None, None)
 
     shared.close.assert_not_called()
+
+
+@pytest.mark.smoke
+def test_rest_client_owns_session_when_none_injected():
+    """Without an injected session the client owns (and will create/close) its own."""
+    client = BAOSRestClient("1.2.3.4")
+    assert client._session is None
+    assert client._owns_session is True
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_rest_client_aexit_without_session_is_safe():
+    """Owned client that never opened a session exits cleanly (nothing to close)."""
+    client = BAOSRestClient("1.2.3.4")
+    client.logout = AsyncMock()
+    # _session is still None; the owned-but-empty branch must not raise.
+    await client.__aexit__(None, None, None)
+    client.logout.assert_awaited_once()

--- a/tests/test_knx_gateway.py
+++ b/tests/test_knx_gateway.py
@@ -10,6 +10,16 @@ from homeassistant.core import HomeAssistant
 from custom_components.luxor_living.knx_gateway import LuxorKNXGateway
 
 
+@pytest.fixture(autouse=True)
+def _mock_shared_session():
+    """Stub HA's shared websession helper so the gateway never builds a real one."""
+    with patch(
+        "custom_components.luxor_living.knx_gateway.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
 @pytest_asyncio.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""

--- a/tests/test_push_client.py
+++ b/tests/test_push_client.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from custom_components.luxor_living.integration_state import IntegrationState
@@ -59,18 +60,30 @@ async def test_push_client_receives_and_forwards(aiohttp_server, socket_enabled)
     fake_hass.async_create_task = lambda coro: asyncio.create_task(coro)
     fake_hass.config_entries.async_get_entry.return_value = entry
 
-    # Start PushClient
-    client = PushClient(fake_hass, entry.entry_id, ws_url)
-    client.start()
+    # PushClient now requests the shared session from HA via async_get_clientsession.
+    # Provide a real session the test owns and closes (stop() no longer closes it).
+    shared_session = aiohttp.ClientSession()
+    try:
+        with patch(
+            "custom_components.luxor_living.push_client.async_get_clientsession",
+            return_value=shared_session,
+        ):
+            # Start PushClient
+            client = PushClient(fake_hass, entry.entry_id, ws_url)
+            client.start()
 
-    # Wait for a short moment to allow connection and message processing
-    await asyncio.sleep(0.2)
+            # Wait for a short moment to allow connection and message processing
+            await asyncio.sleep(0.2)
 
-    # Verify that the gateway received the pushed value at least once
-    assert gateway.process_incoming_value.await_count >= 1
-    # Optionally check latest call args
-    last_call = gateway.process_incoming_value.await_args_list[-1]
-    assert last_call.args == ("1/2/3", True, None)
+            # Verify that the gateway received the pushed value at least once
+            assert gateway.process_incoming_value.await_count >= 1
+            # Optionally check latest call args
+            last_call = gateway.process_incoming_value.await_args_list[-1]
+            assert last_call.args == ("1/2/3", True, None)
 
-    # Clean up
-    await client.stop()
+            # Clean up
+            await client.stop()
+    finally:
+        # PushClient no longer owns the session (HA owns the shared one), so the
+        # test closes the session it injected.
+        await shared_session.close()

--- a/tests/test_push_client_smoke.py
+++ b/tests/test_push_client_smoke.py
@@ -135,12 +135,14 @@ class TestPushClientBackoff:
                 client._stopped = True
 
         with (
-            patch("custom_components.luxor_living.push_client.ClientSession") as mock_session_cls,
+            patch(
+                "custom_components.luxor_living.push_client.async_get_clientsession"
+            ) as mock_get_session,
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
             mock_session = MagicMock()
             mock_session.ws_connect = MagicMock(side_effect=fake_ws_connect)
-            mock_session_cls.return_value = mock_session
+            mock_get_session.return_value = mock_session
             mock_session.close = AsyncMock()
 
             await client._run()
@@ -164,12 +166,14 @@ class TestPushClientBackoff:
                 client._stopped = True
 
         with (
-            patch("custom_components.luxor_living.push_client.ClientSession") as mock_session_cls,
+            patch(
+                "custom_components.luxor_living.push_client.async_get_clientsession"
+            ) as mock_get_session,
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
             mock_session = MagicMock()
             mock_session.ws_connect = MagicMock(side_effect=fake_ws_connect)
-            mock_session_cls.return_value = mock_session
+            mock_get_session.return_value = mock_session
             mock_session.close = AsyncMock()
 
             await client._run()

--- a/tests/test_remove_config_entry_device.py
+++ b/tests/test_remove_config_entry_device.py
@@ -1,0 +1,87 @@
+"""Tests for async_remove_config_entry_device (Gold: stale-device handling)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import Platform
+
+from custom_components.luxor_living import async_remove_config_entry_device
+from custom_components.luxor_living.const import DOMAIN
+from custom_components.luxor_living.integration_state import IntegrationState
+from custom_components.luxor_living.mapped_entity import MappedEntity
+
+
+def _entry_with_device_ids(device_ids):
+    """Build a config entry whose runtime mapper reports the given device ids."""
+    mapper = MagicMock()
+    mapper.entities = [
+        MappedEntity(
+            platform=Platform.LIGHT,
+            unique_id=f"uid_{i}",
+            name="Entity",
+            device_name="Device",
+            device_id=did,
+            entity_type="light",
+            datapoints={},
+            attributes={},
+            parameters={},
+        )
+        for i, did in enumerate(device_ids)
+    ]
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.runtime_data = IntegrationState(mapper=mapper, config={}, overrides={})
+    return entry
+
+
+def _device(*identifiers):
+    device = MagicMock()
+    device.identifiers = set(identifiers)
+    return device
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_stale_device_is_removable():
+    """A device no longer produced by the integration may be removed."""
+    entry = _entry_with_device_ids(["devA"])
+    device = _device((DOMAIN, "devB"))
+    assert await async_remove_config_entry_device(MagicMock(), entry, device) is True
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_active_device_is_not_removable():
+    """A device still mapped by the integration may not be removed."""
+    entry = _entry_with_device_ids(["devA", "devB"])
+    device = _device((DOMAIN, "devA"))
+    assert await async_remove_config_entry_device(MagicMock(), entry, device) is False
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_hub_device_is_not_removable():
+    """The gateway hub device (identifier == entry_id) may not be removed."""
+    entry = _entry_with_device_ids(["devA"])
+    device = _device((DOMAIN, "entry1"))
+    assert await async_remove_config_entry_device(MagicMock(), entry, device) is False
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_missing_runtime_data_allows_removal():
+    """Without runtime data (entry already torn down) stale devices are removable."""
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.runtime_data = None
+    device = _device((DOMAIN, "devA"))
+    assert await async_remove_config_entry_device(MagicMock(), entry, device) is True
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_foreign_identifier_is_removable():
+    """A device with no matching DOMAIN identifier is removable."""
+    entry = _entry_with_device_ids(["devA"])
+    device = _device(("other_domain", "devA"))
+    assert await async_remove_config_entry_device(MagicMock(), entry, device) is True

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -88,9 +88,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "newpass"})
 
@@ -109,9 +115,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.login = AsyncMock(side_effect=AuthenticationError("Bad credentials"))
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "wrong"})
 
@@ -129,9 +141,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.login = AsyncMock(side_effect=RuntimeError("Boom"))
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "pass"})
 


### PR DESCRIPTION
Closes the two deferred quality-scale items from the v1.1.15-rc.1 release.

## Gold — `async_remove_config_entry_device`
Lets users delete devices that are no longer provided by the integration
(removed from the LXP project). The gateway hub (`(DOMAIN, entry_id)`) and any
device still present in the active entity mapping are protected; everything else
is removable. Missing runtime data ⇒ treat as stale (removable).

## Platinum — inject websession
Both internal clients now use HA's shared session instead of owning their own:

- **`BAOSRestClient`**: new optional `session` param. When injected, the client
  uses it and never closes it; every request is bounded by a 30s timeout
  (preserved for the shared session, which has no default total timeout). The
  owned-session path (custom SSL context) is retained as a fallback.
- **`PushClient`**: `_run` uses `async_get_clientsession(self.hass)`; `stop` no
  longer closes the shared session.
- **Call sites** — `config_flow`, `repairs`, `knx_gateway` — pass
  `async_get_clientsession(hass, verify_ssl=False)` (IP1 ships a self-signed cert).

## Tests (TDD, red-first)
- `test_remove_config_entry_device.py` — 5 tests (stale/active/hub/foreign/no-runtime-data)
- `test_inject_websession.py` — 6 tests (push acquires + does-not-close shared session; rest injected + not-closed)
- Updated `test_push_client_smoke` (patch target), `test_repairs` (stub websession), `test_knx_gateway` (autouse websession stub), `test_push_client` (owns injected session)
- Gated suite: **946 passed**, pre-commit clean

## Notes
- The pre-existing `enable_socket` teardown thread-leak in
  `test_push_client_receives_and_forwards` is unchanged and remains excluded from
  the CI gate (verified identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)