### PR TITLE
chore: ignore ETS5 knxprod extraction, local PDFs and HA diagnostic zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ benchmark_results.json
 
 # LXP project files (contain user data)
 *.lxp
+
+# ETS5/knxprod extracted working files and local reference docs
+*.knxprod_FILES/
+docs/*.pdf
+docs/home-assistant_*.zip
 *DEBUG_REPORT*
 *CRITICAL_SETUP*
 create_beta*.sh


### PR DESCRIPTION
Prevents `git add -A` from staging local working files (ETS5/knxprod folder, reference PDFs, HA diagnostic dumps) that pre-commit reformats → breaking commits.