### PR TITLE
fix(tls)!: restore @SECLEVEL=0 + Platinum inject-websession via SSLCipherList.INSECURE (v1.2.0-rc.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,45 @@ documented in this file.
 
 ## [Unreleased]
 
+Pre-release (`v1.2.0-rc.3`).
+
+### Fixed
+
+- **CRITICAL — IP1 legacy TLS (`@SECLEVEL=0`) restored**: `_make_ssl_context`
+  again sets `set_ciphers("DEFAULT:@SECLEVEL=0")`. It had been dropped in
+  `v1.1.15-rc.1` (carried into `v1.2.0-rc.2`) with an untested comment claiming
+  the gateway works without it — but that posture is identical to the failing
+  `v1.2.0-rc.1` shared session, so `v1.2.0-rc.2` was latently affected by the
+  same `SSLV3_ALERT_HANDSHAKE_FAILURE` on real hardware. The only field-proven
+  posture is `v1.1.14`'s `CERT_NONE` + `@SECLEVEL=0`.
+
+### Added
+
+- **Platinum quality scale — inject websession (done correctly)**: the REST
+  client (`BAOSRestClient`) and `PushClient` again accept Home Assistant's shared
+  session, now obtained with `async_get_clientsession(hass, verify_ssl=False,
+  ssl_cipher=SSLCipherList.INSECURE)`. `SSLCipherList.INSECURE` resolves to
+  `"DEFAULT:@SECLEVEL=0"`, so the shared session speaks the IP1's legacy TLS —
+  the missing parameter that broke `v1.2.0-rc.1`. Wired through `knx_gateway.py`,
+  `config_flow.py`, `repairs.py` and `push_client.py`. The owned-session path is
+  kept as a fallback (same `@SECLEVEL=0` context).
+- **Regression guards** (`test_inject_ssl_cipher.py`, gated suite): assert
+  `_make_ssl_context` sets `@SECLEVEL=0` + `CERT_NONE`, that the string matches
+  HA's `SSLCipherList.INSECURE`, and that every injection call site passes
+  `verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE`. A live legacy-cipher
+  handshake cannot be reproduced in CI's modern OpenSSL, so end-to-end TLS
+  remains a manual pre-release check on real hardware.
+
 ## [1.2.0] - 2026-06-18
 
 Pre-release (`v1.2.0-rc.2`). Ships the Gold quality-scale item only. The
 Platinum websession-injection from `v1.2.0-rc.1` has been **reverted** — it
 broke the connection to real IP1 hardware (see below). `v1.1.15-rc.1` remains
 published as a fallback.
+
+> ⚠️ Superseded: `v1.2.0-rc.2` is itself affected by the latent `@SECLEVEL=0`
+> regression described under \[Unreleased] and must not be promoted. Use
+> `v1.2.0-rc.3`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 986](https://img.shields.io/badge/Tests-986%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 992](https://img.shields.io/badge/Tests-992%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/config_flow.py
+++ b/custom_components/luxor_living/config_flow.py
@@ -18,6 +18,8 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import SSLCipherList
 
 from .const import (
     CONF_ALLOW_DIAGNOSTICS,
@@ -447,7 +449,10 @@ class LuxorLivingConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         _LOGGER.debug("🔐 Validating credentials for %s@%s", username, host)
 
-        async with BAOSRestClient(host, port=DEFAULT_HTTP_PORT) as client:
+        session = async_get_clientsession(
+            self.hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE
+        )
+        async with BAOSRestClient(host, port=DEFAULT_HTTP_PORT, session=session) as client:
             # Attempt login - will raise AuthenticationError if invalid
             await client.login(username, password)
             _LOGGER.debug("Credentials validated successfully")

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from typing import Any, Callable, cast
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import SSLCipherList
 from xknx import XKNX
 from xknx.core import XknxConnectionState
 from xknx.dpt import DPTArray, DPTBinary
@@ -141,8 +143,13 @@ class LuxorKNXGateway:
             if self._connection_type == ConnectionType.TUNNELING:
                 _LOGGER.debug("Step 1/3: REST API Login...")
 
-                # Create REST client and enter async context
-                self._rest_client = BAOSRestClient(self.host, port=self.http_port)
+                # Create REST client and enter async context. Inject HA's shared
+                # session configured for the IP1's legacy TLS (no cert verify +
+                # @SECLEVEL=0 via SSLCipherList.INSECURE) — see _make_ssl_context.
+                session = async_get_clientsession(
+                    self.hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE
+                )
+                self._rest_client = BAOSRestClient(self.host, port=self.http_port, session=session)
                 await self._rest_client.__aenter__()
 
                 try:

--- a/custom_components/luxor_living/push_client.py
+++ b/custom_components/luxor_living/push_client.py
@@ -22,6 +22,8 @@ import json
 import logging
 
 from aiohttp import ClientSession, ClientWebSocketResponse
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import SSLCipherList
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +48,11 @@ class PushClient:
         self._task = self.hass.async_create_task(self._run())
 
     async def stop(self) -> None:
-        """Stop the client and cancel background task."""
+        """Stop the client and cancel background task.
+
+        The aiohttp session is owned by Home Assistant (shared via
+        ``async_get_clientsession``) so it is intentionally not closed here.
+        """
         self._stopped = True
         if self._task and not self._task.done():
             self._task.cancel()
@@ -54,16 +60,16 @@ class PushClient:
                 await self._task
             except asyncio.CancelledError:
                 pass
-        if self._session:
-            try:
-                await self._session.close()
-            except Exception as err:
-                _LOGGER.debug("Error closing push client session: %s", err)
+        self._session = None
 
     async def _run(self) -> None:
         """Run connection loop with exponential backoff."""
         backoff = 1.0
-        self._session = ClientSession()
+        # Shared HA session configured for the IP1's legacy TLS (no cert verify +
+        # @SECLEVEL=0). HA owns its lifecycle; we never close it.
+        self._session = async_get_clientsession(
+            self.hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE
+        )
 
         while not self._stopped:
             try:

--- a/custom_components/luxor_living/repairs.py
+++ b/custom_components/luxor_living/repairs.py
@@ -12,6 +12,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import SSLCipherList
 
 from .const import DOMAIN
 from .rest_client import AuthenticationError, BAOSRestClient
@@ -62,7 +64,10 @@ class LuxorLivingAuthenticationRepairFlow(RepairsFlow):
             password = user_input[CONF_PASSWORD]
 
             try:
-                async with BAOSRestClient(host, use_https=True) as client:
+                session = async_get_clientsession(
+                    self.hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE
+                )
+                async with BAOSRestClient(host, use_https=True, session=session) as client:
                     await client.login(username, password)
                     _LOGGER.info("Authentication repair successful for %s", host)
 

--- a/custom_components/luxor_living/rest_client.py
+++ b/custom_components/luxor_living/rest_client.py
@@ -19,14 +19,18 @@ def _make_ssl_context() -> ssl.SSLContext:
     """Return an SSL context for the IP1 gateway.
 
     The IP1 ships with a self-signed certificate so hostname verification and
-    cert chain validation must be disabled. TLS 1.2+ is enforced; @SECLEVEL=0
-    (null/export ciphers) is intentionally NOT set — the gateway supports
-    standard cipher suites without it.
+    cert chain validation must be disabled (``CERT_NONE``). It also negotiates a
+    legacy cipher that modern OpenSSL refuses at its default security level, so
+    ``@SECLEVEL=0`` is REQUIRED — dropping it caused ``SSLV3_ALERT_HANDSHAKE_FAILURE``
+    against real hardware (see v1.2.0-rc.1). This mirrors Home Assistant's
+    ``SSLCipherList.INSECURE`` ("DEFAULT:@SECLEVEL=0"), which the injected shared
+    session uses; this context is the fallback for the owned-session path.
     """
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.set_ciphers("DEFAULT:@SECLEVEL=0")
     return ctx
 
 
@@ -56,7 +60,13 @@ class BAOSRestClient:
     - PUT /rest/device/authtunneling → Enable/Disable Tunneling
     """
 
-    def __init__(self, host: str, port: int = 443, use_https: bool = True):
+    def __init__(
+        self,
+        host: str,
+        port: int = 443,
+        use_https: bool = True,
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
         """
         Initialize REST API Client.
 
@@ -64,6 +74,13 @@ class BAOSRestClient:
             host: IP address of BAOS 777 device
             port: Port for REST API (default: 443 for HTTPS)
             use_https: Use HTTPS for secure communication (default: True, recommended)
+            session: Optional aiohttp session to use. When provided (Home
+                Assistant's shared session from ``async_get_clientsession(hass,
+                verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE)``), the
+                client uses it and never closes it. The caller is responsible for
+                configuring the IP1's legacy TLS (``verify_ssl=False`` +
+                ``ssl_cipher=INSECURE``). When omitted, the client lazily creates
+                and owns its own session built on :func:`_make_ssl_context`.
         """
         self.host = host
         self.port = port
@@ -76,22 +93,26 @@ class BAOSRestClient:
         self.session_expires: Optional[datetime] = None
         self.tunneling_enabled = False
 
-        self._session: Optional[aiohttp.ClientSession] = None
+        self._session: Optional[aiohttp.ClientSession] = session
+        self._owns_session = session is None
+        self._timeout = aiohttp.ClientTimeout(total=30)
 
     async def __aenter__(self):
         """Context manager entry."""
-        loop = asyncio.get_running_loop()
-        ssl_context = await loop.run_in_executor(None, _make_ssl_context)
-        connector = aiohttp.TCPConnector(ssl=ssl_context)
-        self._session = aiohttp.ClientSession(
-            connector=connector, connector_owner=True, timeout=aiohttp.ClientTimeout(total=30)
-        )
+        if self._owns_session and self._session is None:
+            loop = asyncio.get_running_loop()
+            ssl_context = await loop.run_in_executor(None, _make_ssl_context)
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self._session = aiohttp.ClientSession(
+                connector=connector, connector_owner=True, timeout=self._timeout
+            )
         return self
 
     async def __aexit__(self, *args):
         """Context manager exit - ensures cleanup."""
         await self.logout()
-        if self._session:
+        # Only close sessions we own; injected (shared) sessions belong to HA.
+        if self._owns_session and self._session:
             await self._session.close()
 
     async def login(self, username: str, password: str) -> str:
@@ -108,12 +129,12 @@ class BAOSRestClient:
         Raises:
             AuthenticationError: If login fails
         """
-        if not self._session:
+        if not self._session and self._owns_session:
             loop = asyncio.get_running_loop()
             ssl_context = await loop.run_in_executor(None, _make_ssl_context)
             connector = aiohttp.TCPConnector(ssl=ssl_context)
             self._session = aiohttp.ClientSession(
-                connector=connector, connector_owner=True, timeout=aiohttp.ClientTimeout(total=30)
+                connector=connector, connector_owner=True, timeout=self._timeout
             )
 
         url = f"{self.base_url}/rest/login"

--- a/tests/test_inject_ssl_cipher.py
+++ b/tests/test_inject_ssl_cipher.py
@@ -1,0 +1,87 @@
+"""Regression guards for the IP1 legacy-TLS requirement.
+
+The IP1 gateway negotiates a legacy cipher that modern OpenSSL refuses at its
+default security level. Two independent regressions have shipped from forgetting
+this:
+
+* v1.2.0-rc.1 injected Home Assistant's shared session with only
+  ``verify_ssl=False`` (no ``ssl_cipher``) → ``SSLV3_ALERT_HANDSHAKE_FAILURE``.
+* v1.1.15-rc.1 / v1.2.0-rc.2 dropped ``set_ciphers("DEFAULT:@SECLEVEL=0")`` from
+  the owned-session fallback context, with an (untested) comment claiming it was
+  unnecessary — the same handshake failure, latent.
+
+Both are guarded here so neither can silently come back. The required posture is:
+
+* owned-session fallback: :func:`_make_ssl_context` must set
+  ``DEFAULT:@SECLEVEL=0`` and ``CERT_NONE``;
+* every injected-session call site must pass
+  ``verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE`` (HA's
+  ``SSLCipherList.INSECURE`` == ``"DEFAULT:@SECLEVEL=0"``).
+
+These are deterministic (no sockets), so they run in the gated CI suite — the
+exact place the previous regressions slipped through. A live end-to-end TLS check
+against real legacy-cipher hardware remains a manual pre-release step (the IP1's
+specific cipher cannot be reproduced in CI's modern OpenSSL build).
+"""
+
+import ssl
+from pathlib import Path
+
+import pytest
+from homeassistant.util.ssl import SSL_CIPHER_LISTS, SSLCipherList
+
+import custom_components.luxor_living.rest_client as rest_client_mod
+from custom_components.luxor_living.rest_client import _make_ssl_context
+
+COMPONENT_DIR = Path(rest_client_mod.__file__).parent
+
+
+def test_make_ssl_context_sets_seclevel0(monkeypatch):
+    """Owned-session fallback context must enable legacy ciphers (@SECLEVEL=0)."""
+    captured: dict[str, str] = {}
+    real_create = ssl.create_default_context
+
+    def spy_create(*args, **kwargs):
+        ctx = real_create(*args, **kwargs)
+        real_set = ctx.set_ciphers
+
+        def spy_set(cipher_string: str):
+            captured["ciphers"] = cipher_string
+            return real_set(cipher_string)
+
+        ctx.set_ciphers = spy_set  # type: ignore[method-assign]
+        return ctx
+
+    monkeypatch.setattr(rest_client_mod.ssl, "create_default_context", spy_create)
+
+    ctx = _make_ssl_context()
+
+    assert (
+        captured.get("ciphers") == "DEFAULT:@SECLEVEL=0"
+    ), "IP1 needs @SECLEVEL=0; dropping it caused SSLV3_ALERT_HANDSHAKE_FAILURE"
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False
+
+
+def test_seclevel0_matches_ha_insecure_cipher():
+    """Our fallback string must equal what HA's SSLCipherList.INSECURE applies."""
+    assert SSL_CIPHER_LISTS[SSLCipherList.INSECURE] == "DEFAULT:@SECLEVEL=0"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["knx_gateway.py", "config_flow.py", "repairs.py", "push_client.py"],
+)
+def test_call_sites_inject_insecure_cipher(filename):
+    """Every injected-session call site must request the INSECURE cipher list.
+
+    Static guard: the exact regression in v1.2.0-rc.1 was injecting a session
+    with ``verify_ssl=False`` but WITHOUT ``ssl_cipher=INSECURE``.
+    """
+    source = (COMPONENT_DIR / filename).read_text(encoding="utf-8")
+    assert "async_get_clientsession" in source, f"{filename} no longer injects a session"
+    assert "ssl_cipher=SSLCipherList.INSECURE" in source, (
+        f"{filename} injects a session without ssl_cipher=SSLCipherList.INSECURE "
+        "— this reintroduces the IP1 handshake regression"
+    )
+    assert "verify_ssl=False" in source, f"{filename} must disable cert verification for the IP1"

--- a/tests/test_knx_gateway.py
+++ b/tests/test_knx_gateway.py
@@ -10,6 +10,16 @@ from homeassistant.core import HomeAssistant
 from custom_components.luxor_living.knx_gateway import LuxorKNXGateway
 
 
+@pytest.fixture(autouse=True)
+def _mock_shared_session():
+    """Stub HA's shared websession helper so the gateway never builds a real one."""
+    with patch(
+        "custom_components.luxor_living.knx_gateway.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
 @pytest_asyncio.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""

--- a/tests/test_push_client.py
+++ b/tests/test_push_client.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from custom_components.luxor_living.integration_state import IntegrationState
@@ -59,18 +60,30 @@ async def test_push_client_receives_and_forwards(aiohttp_server, socket_enabled)
     fake_hass.async_create_task = lambda coro: asyncio.create_task(coro)
     fake_hass.config_entries.async_get_entry.return_value = entry
 
-    # Start PushClient
-    client = PushClient(fake_hass, entry.entry_id, ws_url)
-    client.start()
+    # PushClient now requests the shared session from HA via async_get_clientsession.
+    # Provide a real session the test owns and closes (stop() no longer closes it).
+    shared_session = aiohttp.ClientSession()
+    try:
+        with patch(
+            "custom_components.luxor_living.push_client.async_get_clientsession",
+            return_value=shared_session,
+        ):
+            # Start PushClient
+            client = PushClient(fake_hass, entry.entry_id, ws_url)
+            client.start()
 
-    # Wait for a short moment to allow connection and message processing
-    await asyncio.sleep(0.2)
+            # Wait for a short moment to allow connection and message processing
+            await asyncio.sleep(0.2)
 
-    # Verify that the gateway received the pushed value at least once
-    assert gateway.process_incoming_value.await_count >= 1
-    # Optionally check latest call args
-    last_call = gateway.process_incoming_value.await_args_list[-1]
-    assert last_call.args == ("1/2/3", True, None)
+            # Verify that the gateway received the pushed value at least once
+            assert gateway.process_incoming_value.await_count >= 1
+            # Optionally check latest call args
+            last_call = gateway.process_incoming_value.await_args_list[-1]
+            assert last_call.args == ("1/2/3", True, None)
 
-    # Clean up
-    await client.stop()
+            # Clean up
+            await client.stop()
+    finally:
+        # PushClient no longer owns the session (HA owns the shared one), so the
+        # test closes the session it injected.
+        await shared_session.close()

--- a/tests/test_push_client_smoke.py
+++ b/tests/test_push_client_smoke.py
@@ -135,12 +135,14 @@ class TestPushClientBackoff:
                 client._stopped = True
 
         with (
-            patch("custom_components.luxor_living.push_client.ClientSession") as mock_session_cls,
+            patch(
+                "custom_components.luxor_living.push_client.async_get_clientsession"
+            ) as mock_get_session,
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
             mock_session = MagicMock()
             mock_session.ws_connect = MagicMock(side_effect=fake_ws_connect)
-            mock_session_cls.return_value = mock_session
+            mock_get_session.return_value = mock_session
             mock_session.close = AsyncMock()
 
             await client._run()
@@ -164,12 +166,14 @@ class TestPushClientBackoff:
                 client._stopped = True
 
         with (
-            patch("custom_components.luxor_living.push_client.ClientSession") as mock_session_cls,
+            patch(
+                "custom_components.luxor_living.push_client.async_get_clientsession"
+            ) as mock_get_session,
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
             mock_session = MagicMock()
             mock_session.ws_connect = MagicMock(side_effect=fake_ws_connect)
-            mock_session_cls.return_value = mock_session
+            mock_get_session.return_value = mock_session
             mock_session.close = AsyncMock()
 
             await client._run()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -88,9 +88,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "newpass"})
 
@@ -109,9 +115,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.login = AsyncMock(side_effect=AuthenticationError("Bad credentials"))
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "wrong"})
 
@@ -129,9 +141,15 @@ class TestLuxorLivingAuthenticationRepairFlow:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.login = AsyncMock(side_effect=RuntimeError("Boom"))
 
-        with patch(
-            "custom_components.luxor_living.repairs.BAOSRestClient",
-            return_value=mock_client,
+        with (
+            patch(
+                "custom_components.luxor_living.repairs.BAOSRestClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "custom_components.luxor_living.repairs.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
         ):
             await flow.async_step_credentials({CONF_USERNAME: "admin", CONF_PASSWORD: "pass"})
 


### PR DESCRIPTION
## Why

Two findings collided:

1. **Platinum** (`inject-websession`) is achievable for the IP1 after all — the rc.1 failure was a single missing parameter. HA's `async_get_clientsession`/`async_create_clientsession` accept `ssl_cipher: SSLCipherList`, and `SSLCipherList.INSECURE` resolves to exactly `"DEFAULT:@SECLEVEL=0"` — the IP1's legacy-TLS requirement. rc.1 passed only `verify_ssl=False` (cert verify off, but SECLEVEL still 2) → `SSLV3_ALERT_HANDSHAKE_FAILURE`.

2. **Critical latent bug found while implementing**: `_make_ssl_context` on `main` (= v1.1.15-rc.1 / v1.2.0-rc.2) had **dropped** `set_ciphers("DEFAULT:@SECLEVEL=0")` on an untested comment. That posture (`CERT_NONE` + default SECLEVEL) is identical to rc.1's failing shared session → **rc.2 is latently broken too** and must not be promoted. Only `v1.1.14` (`CERT_NONE` + `@SECLEVEL=0`) is field-proven.

## Changes

- `rest_client._make_ssl_context`: restore `set_ciphers("DEFAULT:@SECLEVEL=0")` (owned-session fallback).
- Re-introduce injected-session support on `BAOSRestClient`; inject `async_get_clientsession(hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE)` at all call sites: `knx_gateway.py`, `config_flow.py`, `repairs.py`, `push_client.py`.
- New gated guards (`tests/test_inject_ssl_cipher.py`):
  - `_make_ssl_context` sets `@SECLEVEL=0` + `CERT_NONE`,
  - our string == HA `SSLCipherList.INSECURE`,
  - every call site injects `verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE`.

## Validation

- Gated suite: **930 passed, 38 deselected**. pre-commit green. README badge 986 → 992.
- ⚠️ A real legacy-cipher handshake **cannot** be reproduced in CI's modern OpenSSL (RC4/3DES compiled out; `CERT_NONE` skips cert key-size SECLEVEL checks). The guards lock the *configuration*; **end-to-end TLS must be confirmed on real IP1 hardware before promoting** (the exact gap that let rc.1 and rc.2 through).

## Release follow-up

- This supersedes `v1.2.0-rc.2` (latently broken). Cut `v1.2.0-rc.3` after merge.
- Do **not** ask the tester to validate rc.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
