### PR TITLE
fix(security): push forwarder must not inherit IP1 legacy-TLS downgrade (v1.2.0-rc.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,30 @@ documented in this file.
 
 ## [Unreleased]
 
-Pre-release (`v1.2.0-rc.3`).
+Pre-release (`v1.2.0-rc.4`).
+
+### Security
+
+- **Push forwarder no longer downgrades TLS**: `v1.2.0-rc.3` made `PushClient`
+  use `async_get_clientsession(hass, verify_ssl=False, ssl_cipher=INSECURE)` —
+  but `push_ws_url` is a user-configured forwarder, **not** the IP1. That blanket
+  application disabled certificate verification and lowered the cipher security
+  level for an arbitrary, possibly internet-facing, token-authenticated endpoint
+  (MITM / token-theft risk). `PushClient` now uses HA's standard shared session
+  with full TLS verification. The IP1 legacy-TLS posture is confined to the three
+  IP1-REST call sites (`knx_gateway`, `config_flow`, `repairs`). Only entries
+  with `push_ws_url` configured were affected. Guarded by
+  `test_push_client_does_not_downgrade_tls`.
+
+### Fixed (rc.4)
+
+- **Request timeouts on the injected session**: `login`/`logout`/`enable_tunneling`
+  now pass an explicit per-request `timeout` (30 s). The owned session set this at
+  session level; HA's shared session uses aiohttp's defaults (total 300 s), so the
+  explicit timeout restores the intended 30 s ceiling on the injected path.
+- **`_async_forced_refresh` error handling**: the fire-and-forget REST-refresh task
+  now catches exceptions (like `_async_on_reconnect`) instead of surfacing an
+  unhandled task error when a refresh login fails.
 
 ### Fixed
 

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -336,12 +336,22 @@ class LuxorKNXGateway:
         if not self._rest_client or self.simulation_mode:
             return
         async with self._session_lock:
-            await self._rest_client.logout()
-            await self._rest_client.login(self.username, self.password)
-            await self._rest_client.enable_tunneling()
-            self._connected = True
-            self._last_refresh_at = time.monotonic()
-            _LOGGER.info("REST session refresh complete (host=%s)", self.host)
+            try:
+                await self._rest_client.logout()
+                await self._rest_client.login(self.username, self.password)
+                await self._rest_client.enable_tunneling()
+                self._connected = True
+                self._last_refresh_at = time.monotonic()
+                _LOGGER.info("REST session refresh complete (host=%s)", self.host)
+            except Exception as err:
+                # Fire-and-forget task: never let the exception escape unhandled.
+                self._connected = False
+                _LOGGER.error(
+                    "REST session refresh failed (host=%s): %s — "
+                    "reload the integration if the gateway remains unreachable",
+                    self.host,
+                    err,
+                )
 
     def _on_connection_state_changed(self, state: XknxConnectionState) -> None:
         """Handle xknx connection state changes.

--- a/custom_components/luxor_living/push_client.py
+++ b/custom_components/luxor_living/push_client.py
@@ -23,7 +23,6 @@ import logging
 
 from aiohttp import ClientSession, ClientWebSocketResponse
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util.ssl import SSLCipherList
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,11 +64,12 @@ class PushClient:
     async def _run(self) -> None:
         """Run connection loop with exponential backoff."""
         backoff = 1.0
-        # Shared HA session configured for the IP1's legacy TLS (no cert verify +
-        # @SECLEVEL=0). HA owns its lifecycle; we never close it.
-        self._session = async_get_clientsession(
-            self.hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE
-        )
+        # The push websocket is a user-configured forwarder (push_ws_url), NOT the
+        # IP1 — it must keep normal TLS verification. The IP1's legacy-TLS
+        # workaround must NOT leak here, or it would disable certificate checks
+        # for an arbitrary, possibly internet-facing, token-authenticated
+        # endpoint. Use HA's standard shared session (full verification).
+        self._session = async_get_clientsession(self.hass)
 
         while not self._stopped:
             try:

--- a/custom_components/luxor_living/rest_client.py
+++ b/custom_components/luxor_living/rest_client.py
@@ -143,7 +143,7 @@ class BAOSRestClient:
         _LOGGER.debug(f"Attempting login to {url} with user: {username}")
 
         try:
-            async with self._session.post(url, json=payload) as response:
+            async with self._session.post(url, json=payload, timeout=self._timeout) as response:
                 _LOGGER.debug(f"Login response status: {response.status}")
                 _LOGGER.debug(f"Login response headers: {response.headers}")
 
@@ -198,7 +198,7 @@ class BAOSRestClient:
         _LOGGER.debug(f"Logging out from {url}")
 
         try:
-            async with self._session.post(url, headers=headers) as response:
+            async with self._session.post(url, headers=headers, timeout=self._timeout) as response:
                 if response.status in (200, 204):  # API returns 204 per docs
                     _LOGGER.info("Logout successful. Tunneling auto-deactivated.")
                 else:
@@ -244,7 +244,9 @@ class BAOSRestClient:
                 "set" if self.session_token else "missing",
             )
 
-            async with self._session.put(url, json=payload, headers=headers) as response:
+            async with self._session.put(
+                url, json=payload, headers=headers, timeout=self._timeout
+            ) as response:
                 _LOGGER.debug(f"Tunneling response status: {response.status}")
                 _LOGGER.debug(f"Tunneling response headers: {response.headers}")
 

--- a/tests/test_inject_ssl_cipher.py
+++ b/tests/test_inject_ssl_cipher.py
@@ -68,12 +68,15 @@ def test_seclevel0_matches_ha_insecure_cipher():
     assert SSL_CIPHER_LISTS[SSLCipherList.INSECURE] == "DEFAULT:@SECLEVEL=0"
 
 
-@pytest.mark.parametrize(
-    "filename",
-    ["knx_gateway.py", "config_flow.py", "repairs.py", "push_client.py"],
-)
-def test_call_sites_inject_insecure_cipher(filename):
-    """Every injected-session call site must request the INSECURE cipher list.
+# Only these talk to the IP1's REST API (host from config) — they need the
+# legacy-TLS posture. push_client is deliberately excluded: it connects to a
+# user-configured forwarder (push_ws_url), not the IP1, and must keep normal TLS.
+IP1_REST_CALL_SITES = ["knx_gateway.py", "config_flow.py", "repairs.py"]
+
+
+@pytest.mark.parametrize("filename", IP1_REST_CALL_SITES)
+def test_ip1_call_sites_inject_insecure_cipher(filename):
+    """Every IP1-REST call site must request the INSECURE cipher list.
 
     Static guard: the exact regression in v1.2.0-rc.1 was injecting a session
     with ``verify_ssl=False`` but WITHOUT ``ssl_cipher=INSECURE``.
@@ -85,3 +88,16 @@ def test_call_sites_inject_insecure_cipher(filename):
         "— this reintroduces the IP1 handshake regression"
     )
     assert "verify_ssl=False" in source, f"{filename} must disable cert verification for the IP1"
+
+
+def test_push_client_does_not_downgrade_tls():
+    """push_client must NOT carry the IP1 legacy-TLS downgrade.
+
+    ``push_ws_url`` is an arbitrary, possibly internet-facing, token-authenticated
+    endpoint — disabling cert verification / lowering SECLEVEL there would be a
+    security regression (it was, briefly, in v1.2.0-rc.3).
+    """
+    source = (COMPONENT_DIR / "push_client.py").read_text(encoding="utf-8")
+    assert "async_get_clientsession" in source, "push_client should use HA's shared session"
+    assert "ssl_cipher" not in source, "push_client must not weaken ciphers for the forwarder"
+    assert "verify_ssl=False" not in source, "push_client must keep TLS verification"


### PR DESCRIPTION
## Security fix (found by focused code review of the connection/TLS path)

`v1.2.0-rc.3` blanket-applied the IP1 legacy-TLS workaround to `PushClient`:

```python
async_get_clientsession(hass, verify_ssl=False, ssl_cipher=SSLCipherList.INSECURE)
```

But `push_ws_url` is a **user-configured forwarder endpoint**, not the IP1. This disabled certificate verification **and** lowered the OpenSSL security level for an arbitrary, possibly internet-facing, **token-authenticated** websocket → MITM / token-theft risk + weakened crypto. Only entries with `push_ws_url` configured were affected (the push client isn't started otherwise).

### Fix
- `PushClient` uses `async_get_clientsession(hass)` — **full TLS verification**.
- IP1 legacy-TLS posture stays confined to the IP1-REST call sites (`knx_gateway`, `config_flow`, `repairs`).
- New guard `test_push_client_does_not_downgrade_tls`; call-site INSECURE guard parametrize no longer includes `push_client`.

## rc.4 hardening (same review)
- `login`/`logout`/`enable_tunneling` pass an explicit per-request `timeout` (30 s). The injected shared session otherwise uses aiohttp defaults (total 300 s) vs the owned session's 30 s.
- `_async_forced_refresh` now catches exceptions like `_async_on_reconnect` — no unhandled fire-and-forget task error when a refresh login fails.

## Validation
- Gated suite: **930 passed, 38 deselected**. pre-commit green.

## Release
- Supersedes `v1.2.0-rc.3`. Cut `v1.2.0-rc.4` after merge; give the tester rc.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
