### PR TITLE
fix: flush stale IP1 tunneling slots on startup to prevent KNX lockup

### DIFF
--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -161,12 +161,29 @@ class LuxorKNXGateway:
                     self._rest_client = None
                     raise err  # Re-raise to trigger circuit breaker
 
-                # Step 2: Enable KNX Tunneling
+                # Step 2: Flush stale IP1 tunneling sessions, then enable.
+                # disable_tunneling() is a global device-level call that releases
+                # ALL occupied slots regardless of which client holds them — this
+                # clears sessions left by a previous HA instance that crashed
+                # without a clean logout. Risk: briefly disconnects LuxorPlay if
+                # it holds the slot, but it reconnects automatically and this is
+                # far preferable to a full IP1 lockup from slot exhaustion.
+                _LOGGER.debug("Step 2/3: Flushing stale tunneling sessions...")
+                await self._rest_client.disable_tunneling()
                 _LOGGER.debug("Step 2/3: Enabling KNX Tunneling...")
                 try:
                     await self._rest_client.enable_tunneling()
                     self._tunneling_enabled = True
                     _LOGGER.debug("KNX Tunneling enabled")
+                    try:
+                        status = await self._rest_client.get_tunneling_status()
+                        _LOGGER.info(
+                            "IP1 tunneling slots: %s/%s connected",
+                            status.get("connectedClients", "?"),
+                            status.get("maxSlots", "?"),
+                        )
+                    except Exception:
+                        pass  # diagnostic only, never block startup
                 except TunnelingError as err:
                     _LOGGER.error("Failed to enable tunneling: %s", err)
                     await self._rest_client.__aexit__(None, None, None)

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -168,6 +168,15 @@ class LuxorKNXGateway:
                 # without a clean logout. Risk: briefly disconnects LuxorPlay if
                 # it holds the slot, but it reconnects automatically and this is
                 # far preferable to a full IP1 lockup from slot exhaustion.
+                try:
+                    status = await self._rest_client.get_tunneling_status()
+                    _LOGGER.info(
+                        "IP1 tunneling slots before flush: %s/%s connected",
+                        status.get("connectedClients", "?"),
+                        status.get("maxSlots", "?"),
+                    )
+                except Exception:
+                    pass  # diagnostic only, never block startup
                 _LOGGER.debug("Step 2/3: Flushing stale tunneling sessions...")
                 await self._rest_client.disable_tunneling()
                 _LOGGER.debug("Step 2/3: Enabling KNX Tunneling...")
@@ -175,15 +184,6 @@ class LuxorKNXGateway:
                     await self._rest_client.enable_tunneling()
                     self._tunneling_enabled = True
                     _LOGGER.debug("KNX Tunneling enabled")
-                    try:
-                        status = await self._rest_client.get_tunneling_status()
-                        _LOGGER.info(
-                            "IP1 tunneling slots: %s/%s connected",
-                            status.get("connectedClients", "?"),
-                            status.get("maxSlots", "?"),
-                        )
-                    except Exception:
-                        pass  # diagnostic only, never block startup
                 except TunnelingError as err:
                     _LOGGER.error("Failed to enable tunneling: %s", err)
                     await self._rest_client.__aexit__(None, None, None)

--- a/custom_components/luxor_living/rest_client.py
+++ b/custom_components/luxor_living/rest_client.py
@@ -323,7 +323,6 @@ class BAOSRestClient:
             _LOGGER.error(f"Error disabling tunneling: {e}")
             return False
 
-    # NOT CALLED BY INTEGRATION — reserved for future diagnostics/health checks
     async def get_tunneling_status(self) -> Dict[str, Any]:
         """
         Get current tunneling status.


### PR DESCRIPTION
## Problem

When HA crashes without a clean shutdown, `logout()` never fires and the IP1 keeps the tunneling slot marked as occupied. After multiple such events the IP1's session table fills up — locking out both the HA integration **and LuxorPlay** (confirmed symptom in issue #141: both unable to steer).

## Root Cause

The IP1 (BAOS 777) has a limited KNX tunneling slot table. Stale sessions from crashed HA instances accumulate until the table is full. Physical power cycle of the KNX system was the only recovery.

Our 4h `SESSION_REFRESH_INTERVAL` cleans up *our own* session but cannot release slots held by dead previous instances.

## Fix

**`knx_gateway.py`**: Call `disable_tunneling()` before `enable_tunneling()` on every connect.  
`PUT /rest/device/authtunneling {"enabled": false}` is a global device-level operation — it releases ALL occupied slots regardless of which client holds them, clearing stale sessions from previous crashed HA instances.

**`knx_gateway.py`**: Call `get_tunneling_status()` *before* the flush and log `connectedClients/maxSlots` as INFO. Users can share a standard HA log download — the log will show `IP1 tunneling slots before flush: 2/1 connected` on the next incident, confirming slot exhaustion without requiring manual REST API calls.

## Risk

`disable_tunneling()` briefly disconnects LuxorPlay if it holds a slot at the moment of HA startup/reload. LuxorPlay auto-reconnects. This is far preferable to a complete IP1 lockup.

## Test Plan

- [ ] 954/954 tests passing
- [ ] All pre-commit hooks green (black, isort, flake8, bandit)
- [ ] Closes #141 (pending confirmation from reporter after rc update)

Fixes #141