### PR TITLE
fix(#141): sync H6 heat/cool state across shared mode-switch GA

### DIFF
--- a/custom_components/luxor_living/climate.py
+++ b/custom_components/luxor_living/climate.py
@@ -198,6 +198,11 @@ class LuxorClimate(ClimateEntity):
             self.knx_gateway.register_listener(addr, self._handle_window_contact_update)
             self._knx_listener_refs.append((addr, self._handle_window_contact_update))
 
+        if "UmschaltenHeitzenKühlen" in self._datapoints:
+            addr = self._datapoints["UmschaltenHeitzenKühlen"]
+            self.knx_gateway.register_listener(addr, self._handle_mode_switch_update)
+            self._knx_listener_refs.append((addr, self._handle_mode_switch_update))
+
         # Request initial temperature state — wait up to 5s for KNX connection
         if self.knx_gateway.connected:
             await self._update_temperature()
@@ -225,6 +230,19 @@ class LuxorClimate(ClimateEntity):
         if value is not None:
             self._window_contact_open = bool(value)
             self.async_write_ha_state()
+
+    def _handle_mode_switch_update(self, group_address: str, value: Any) -> None:
+        """Handle heating/cooling mode-switch telegram received via KNX.
+
+        UmschaltenHeitzenKühlen is a shared GA — one physical switch drives all
+        H6 devices on the bus at once, so every H6 entity must listen for it,
+        not just the one that sent the command. OFF is a local-only pseudo
+        state (not represented on the bus), so it's never overwritten here.
+        """
+        if value is None or self._attr_hvac_mode == HVACMode.OFF:
+            return
+        self._attr_hvac_mode = HVACMode.HEAT if value else HVACMode.COOL
+        self.async_write_ha_state()
 
     async def _update_temperature(self) -> None:
         """Request current and target temperatures from KNX bus."""

--- a/tests/test_h6_cooling_mode.py
+++ b/tests/test_h6_cooling_mode.py
@@ -256,3 +256,75 @@ class TestClimateHVACModes:
 
         # Verify binary telegram sent to mode-switch with 1 (heating)
         mock_knx_gateway.async_send_telegram.assert_called_with(102, 1, "binary")
+
+
+class TestModeSwitchListenerSync:
+    """Test that H6 entities stay in sync via the shared mode-switch GA.
+
+    UmschaltenHeitzenKühlen is one physical switch driving all H6 devices at
+    once — every H6 entity must listen for it, not just the one commanded
+    from HA, otherwise other entities show stale heat/cool state (#141).
+    """
+
+    def _make_cooling_entity(self, mock_coordinator, mock_knx_gateway, unique_id="test_climate"):
+        from custom_components.luxor_living.climate import LuxorClimate
+        from custom_components.luxor_living.mapped_entity import MappedEntity
+
+        mapped_entity = MappedEntity(
+            platform=Platform.CLIMATE,
+            unique_id=unique_id,
+            name="Test Climate",
+            device_name="511 H6",
+            device_id="test_h6_id",
+            entity_type="climate",
+            datapoints={"Sollwert": 100, "Istwert": 101, "UmschaltenHeitzenKühlen": 102},
+            attributes={},
+            parameters={"heizungsart": "102"},
+            cooling_capable=True,
+        )
+        entity = LuxorClimate(
+            coordinator=mock_coordinator,
+            knx_gateway=mock_knx_gateway,
+            mapped_entity=mapped_entity,
+            entry_id="test_entry",
+        )
+        entity.async_write_ha_state = lambda: None
+        return entity
+
+    @pytest.mark.asyncio
+    async def test_mode_switch_listener_registered(self, hass, mock_coordinator, mock_knx_gateway):
+        """async_added_to_hass must register a listener on the mode-switch GA."""
+        mock_knx_gateway.connected = False  # skip initial bus read, only check registration
+        entity = self._make_cooling_entity(mock_coordinator, mock_knx_gateway)
+
+        await entity.async_added_to_hass()
+
+        registered = [c[0][0] for c in mock_knx_gateway.register_listener.call_args_list]
+        assert 102 in registered
+
+    def test_incoming_telegram_cool_updates_other_entity(self, mock_coordinator, mock_knx_gateway):
+        """A mode-switch telegram from another device's command must flip this entity to COOL."""
+        entity = self._make_cooling_entity(mock_coordinator, mock_knx_gateway)
+        entity._attr_hvac_mode = HVACMode.HEAT
+
+        entity._handle_mode_switch_update(102, 0)
+
+        assert entity.hvac_mode == HVACMode.COOL
+
+    def test_incoming_telegram_heat_updates_other_entity(self, mock_coordinator, mock_knx_gateway):
+        """A mode-switch telegram value 1 must flip this entity to HEAT."""
+        entity = self._make_cooling_entity(mock_coordinator, mock_knx_gateway)
+        entity._attr_hvac_mode = HVACMode.COOL
+
+        entity._handle_mode_switch_update(102, 1)
+
+        assert entity.hvac_mode == HVACMode.HEAT
+
+    def test_incoming_telegram_does_not_override_off(self, mock_coordinator, mock_knx_gateway):
+        """OFF is a local-only pseudo state and must not be clobbered by bus telegrams."""
+        entity = self._make_cooling_entity(mock_coordinator, mock_knx_gateway)
+        entity._attr_hvac_mode = HVACMode.OFF
+
+        entity._handle_mode_switch_update(102, 0)
+
+        assert entity.hvac_mode == HVACMode.OFF


### PR DESCRIPTION
## Summary
- `UmschaltenHeitzenKühlen` is one shared GA driving all H6 devices at once, but no H6 entity listened for it — only the entity that sent the command updated locally, so sibling devices on the same switch showed stale heat/cool mode.
- Registers a KNX listener on the mode-switch GA (same pattern as Istwert/Sollwert/WindowContact) and updates `hvac_mode` from incoming telegrams, without touching the local-only OFF pseudo-state.

Root cause found via Marcus' report in #141 (bathroom → cooling switches all H6 devices physically, but only bathroom shows "cooling" in HA).

## Test plan
- [x] New tests in `tests/test_h6_cooling_mode.py::TestModeSwitchListenerSync` (listener registration, HEAT/COOL sync from bus, OFF not clobbered)
- [x] Full climate + h6-cooling-mode suite passes
- [x] pre-commit clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>