### PR TITLE
fix(#141): correct Wetterstation Helligkeit sensor position labels

### DIFF
--- a/custom_components/luxor_living/entity_mapper.py
+++ b/custom_components/luxor_living/entity_mapper.py
@@ -535,12 +535,20 @@ class EntityMapper:
         Uses PlatformDetector for role-to-attributes mapping.
         """
         # Role -> entity_name_suffix mapping (uses PlatformDetector for class/unit)
+        #
+        # The role strings below come straight from Theben's LXP export and do
+        # NOT match physical sensor position — confirmed via #141 by comparing
+        # live values against LuxorPlay (ground truth) for the same install:
+        # it's a 3-way rotation, not a simple Vorne/Mitte rename.
+        #   role HelligkeitMitte  is physically "Links"
+        #   role HelligkeitLinks  is physically "Rechts"
+        #   role HelligkeitRechts is physically "Vorne"
         wetterstation_roles = {
             "Temperatur": "Außentemperatur",
             "Windgeschwindigkeit": "Windgeschwindigkeit",
-            "HelligkeitMitte": "Helligkeit Vorne",
-            "HelligkeitLinks": "Helligkeit Links",
-            "HelligkeitRechts": "Helligkeit Rechts",
+            "HelligkeitMitte": "Helligkeit Links",
+            "HelligkeitLinks": "Helligkeit Rechts",
+            "HelligkeitRechts": "Helligkeit Vorne",
             "Regen": "Regen",  # Binary/status
         }
 

--- a/tests/test_entity_mapper_extended.py
+++ b/tests/test_entity_mapper_extended.py
@@ -296,6 +296,32 @@ class TestWetterstationMapping:
         sensors = mapper.get_entities_by_platform(Platform.SENSOR)
         assert len(sensors) == len(roles)
 
+    def test_helligkeit_roles_map_to_physically_correct_position(self):
+        """Confirmed via #141: LXP role text does not match physical sensor position.
+
+        LuxorPlay (ground truth, same LXP file) vs. our old labels showed a
+        3-way rotation, not a simple two-way swap:
+          role HelligkeitMitte  (addr 10244) is physically "Links"
+          role HelligkeitLinks  (addr 10243) is physically "Rechts"
+          role HelligkeitRechts (addr 10245) is physically "Vorne"
+        """
+        roles = ["HelligkeitMitte", "HelligkeitLinks", "HelligkeitRechts"]
+        datapoints = [
+            _datapoint(
+                r, 10244 if r == "HelligkeitMitte" else 10243 if r == "HelligkeitLinks" else 10245
+            )
+            for r in roles
+        ]
+        sensor = _sensor("Weather", 1, datapoints)
+        device = _device("Wetterstation Dach", sensors=[sensor])
+        mapper = _mapper([device])
+        sensors = mapper.get_entities_by_platform(Platform.SENSOR)
+
+        by_addr = {addr: e.name for e in sensors for addr in e.datapoints.values()}
+        assert "Links" in by_addr[10244]
+        assert "Rechts" in by_addr[10243]
+        assert "Vorne" in by_addr[10245]
+
 
 # ── Query methods ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- rc.5 fixed the "Mitte" → "Vorne" naming, but Marcus (#141) confirmed the underlying values are still wrong — not a simple two-way swap, a 3-way rotation between all three brightness sensors.
- Verified against Marcus' actual LXP export and his side-by-side LuxorPlay vs. HA screenshot values:
  - role `HelligkeitMitte`  is physically **Links**
  - role `HelligkeitLinks`  is physically **Rechts**
  - role `HelligkeitRechts` is physically **Vorne**
- This is Theben's own ComObject/role labeling, not a parser bug on our side — LXP role↔address pairing is internally consistent, the role text itself just doesn't match physical mounting position for this sensor.

## Test plan
- [x] New test `test_helligkeit_roles_map_to_physically_correct_position` in `tests/test_entity_mapper_extended.py`, asserting the corrected role→name mapping by address
- [x] Full entity_mapper suite passes
- [x] pre-commit clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>