### PR TITLE
feat(#141): raise diagnostics entity cap from 50 to 200

### DIFF
--- a/custom_components/luxor_living/diagnostics.py
+++ b/custom_components/luxor_living/diagnostics.py
@@ -117,8 +117,9 @@ async def async_get_config_entry_diagnostics(
             entity_list: list[dict[str, Any]] = []
             diagnostics["entities"] = entity_list
 
-            # Collect entity details (limit to 50 for performance)
-            for entity in entities[:50]:
+            # Collect entity details (limit to 200 for performance — #141: 160-entity
+            # installs were hitting the old 50 cap and losing most of the export)
+            for entity in entities[:200]:
                 # MappedEntity objects have attributes
                 entity_info = {
                     "unique_id": getattr(entity, "unique_id", "unknown"),

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -334,12 +334,12 @@ async def test_diagnostics_gateway_exception(mock_config_entry, mock_hass_data):
 
 @pytest.mark.asyncio
 async def test_diagnostics_entity_limit(mock_config_entry, mock_hass_data):
-    """Test that diagnostics limits entity details to 50."""
+    """Test that diagnostics limits entity details to 200 (#141: 160-entity installs need headroom)."""
     hass = MagicMock(spec=HomeAssistant)
 
-    # Create 100 entities
+    # Create 250 entities
     entities = []
-    for i in range(100):
+    for i in range(250):
         entities.append(
             MappedEntity(
                 platform=Platform.LIGHT,
@@ -359,9 +359,9 @@ async def test_diagnostics_entity_limit(mock_config_entry, mock_hass_data):
 
     diag = await async_get_config_entry_diagnostics(hass, mock_config_entry)
 
-    # Should limit to 50 in details but show total in summary
-    assert len(diag["entities"]) == 50
-    assert diag["entity_summary"]["total"] == 100
+    # Should limit to 200 in details but show total in summary
+    assert len(diag["entities"]) == 200
+    assert diag["entity_summary"]["total"] == 250
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Marcus (#141) asked for a full YAML/local-KNX-address export of his ~160-entity system; "Download Diagnostics" already exports entities + datapoints but was capped at 50, silently dropping most installs of that size.
- Raises the cap to 200 — comfortable headroom, negligible cost for a debug export.

## Test plan
- [x] Updated `test_diagnostics_entity_limit` to 250 generated entities, asserts cap at 200 / total reported correctly
- [x] Full diagnostics suite passes
- [x] pre-commit clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>