### PR TITLE
fix(cover): tilt position inversion (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 1033](https://img.shields.io/badge/Tests-1033%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 1034](https://img.shields.io/badge/Tests-1034%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/cover.py
+++ b/custom_components/luxor_living/cover.py
@@ -215,7 +215,8 @@ class LuxorCover(CoverEntity):
     def _handle_tilt_update(self, group_address: str, value: Any) -> None:
         """Handle tilt position update received via KNX telegram."""
         if isinstance(value, (int, float)):
-            self._attr_current_cover_tilt_position = int(value)
+            # KNX Lamelle% convention: 0 = open, 100 = closed → invert (#197)
+            self._attr_current_cover_tilt_position = 100 - int(value)
             self.async_write_ha_state()
 
     async def _update_position(self) -> None:
@@ -299,8 +300,9 @@ class LuxorCover(CoverEntity):
 
         try:
             if "Lamelle%" in self._datapoints:
+                # KNX Lamelle% convention: 0 = open, 100 = closed (#197)
                 await self.knx_gateway.async_send_telegram(
-                    self._datapoints["Lamelle%"], 100, "percent"
+                    self._datapoints["Lamelle%"], 0, "percent"
                 )
                 _LOGGER.info("Opening tilt for cover: %s", self.name)
         except Exception as e:
@@ -316,8 +318,9 @@ class LuxorCover(CoverEntity):
 
         try:
             if "Lamelle%" in self._datapoints:
+                # KNX Lamelle% convention: 0 = open, 100 = closed (#197)
                 await self.knx_gateway.async_send_telegram(
-                    self._datapoints["Lamelle%"], 0, "percent"
+                    self._datapoints["Lamelle%"], 100, "percent"
                 )
                 _LOGGER.info("Closing tilt for cover: %s", self.name)
         except Exception as e:
@@ -354,11 +357,13 @@ class LuxorCover(CoverEntity):
 
         try:
             if "Lamelle%" in self._datapoints:
+                # Invert HA tilt position to KNX Lamelle% convention (#197)
+                knx_tilt = 100 - int(tilt_position)
                 success = await self.knx_gateway.async_send_telegram(
-                    self._datapoints["Lamelle%"], int(tilt_position), "percent"
+                    self._datapoints["Lamelle%"], knx_tilt, "percent"
                 )
                 if success:
-                    self._attr_current_cover_tilt_position = tilt_position
+                    self._attr_current_cover_tilt_position = int(tilt_position)
                     self.async_write_ha_state()
                     _LOGGER.info("Set tilt position for %s to %d%%", self.name, tilt_position)
         except Exception as e:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -282,8 +282,8 @@ class TestLuxorCover:
 
         await entity.async_open_cover_tilt()
 
-        # Should send 100% to Lamelle% address as percent
-        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 100, "percent")
+        # Should send KNX 0% to Lamelle% address (0 = open per KNX convention, #197)
+        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 0, "percent")
 
     @pytest.mark.asyncio
     async def test_close_tilt(self, mock_coordinator, mock_knx_gateway, blind_mapped_entity):
@@ -297,8 +297,8 @@ class TestLuxorCover:
 
         await entity.async_close_cover_tilt()
 
-        # Should send 0% to Lamelle% address as percent
-        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 0, "percent")
+        # Should send KNX 100% to Lamelle% address (100 = closed per KNX convention, #197)
+        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 100, "percent")
 
     @pytest.mark.asyncio
     async def test_set_tilt_position(self, mock_coordinator, mock_knx_gateway, blind_mapped_entity):
@@ -313,8 +313,8 @@ class TestLuxorCover:
 
         await entity.async_set_cover_tilt_position(**{ATTR_TILT_POSITION: 60})
 
-        # Should send percent value to Lamelle% address (9222)
-        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 60, "percent")
+        # Should send inverted percent value to Lamelle% address (100-60=40, #197)
+        mock_knx_gateway.async_send_telegram.assert_called_once_with(9222, 40, "percent")
         assert entity.current_cover_tilt_position == 60
 
     def test_available_when_connected(
@@ -730,7 +730,11 @@ class TestCoverMutationTargets:
     async def test_tilt_position_inverted_correctly(
         self, mock_coordinator, mock_knx_gateway, blind_mapped_entity
     ):
-        """Kill off-by-one mutations in tilt inversion."""
+        """Kill off-by-one mutations in tilt inversion.
+
+        Lamelle% follows the same KNX convention as Höhe%: 0 = open, 100 = closed.
+        HA tilt position 75 (75% open) must send KNX 25 (#197).
+        """
         entity = LuxorCover(
             coordinator=mock_coordinator,
             knx_gateway=mock_knx_gateway,
@@ -742,8 +746,27 @@ class TestCoverMutationTargets:
         await entity.async_set_cover_tilt_position(**{ATTR_TILT_POSITION: 75})
 
         call_args = mock_knx_gateway.async_send_telegram.call_args
-        assert call_args[0][1] == 75  # tilt passes through unchanged
+        assert call_args[0][1] == 25  # 100 - 75
         assert call_args[0][2] == "percent"
+        assert entity.current_cover_tilt_position == 75
+
+    @pytest.mark.smoke
+    @pytest.mark.asyncio
+    async def test_handle_tilt_update_inverted_correctly(
+        self, mock_coordinator, mock_knx_gateway, blind_mapped_entity
+    ):
+        """#197: KNX Lamelle% 75 (75% closed) must map to HA tilt position 25."""
+        entity = LuxorCover(
+            coordinator=mock_coordinator,
+            knx_gateway=mock_knx_gateway,
+            mapped_entity=blind_mapped_entity,
+            entry_id="e1",
+        )
+        entity.async_write_ha_state = MagicMock()
+
+        entity._handle_tilt_update(8711, 75)
+
+        assert entity.current_cover_tilt_position == 25
 
     # ── async_added_to_hass: listener key names ───────────────────────────
 

--- a/tests/test_cover_extended.py
+++ b/tests/test_cover_extended.py
@@ -241,7 +241,7 @@ class TestSetPosition:
 
 class TestTiltCommands:
     @pytest.mark.asyncio
-    async def test_open_tilt_sends_100(self):
+    async def test_open_tilt_sends_0(self):
         entity, gateway = _make_cover(
             [
                 {"role": "UpDown", "address": 200},
@@ -249,7 +249,7 @@ class TestTiltCommands:
             ]
         )
         await entity.async_open_cover_tilt()
-        gateway.async_send_telegram.assert_awaited_once_with(204, 100, "percent")
+        gateway.async_send_telegram.assert_awaited_once_with(204, 0, "percent")
 
     @pytest.mark.asyncio
     async def test_open_tilt_no_tilt_does_nothing(self):
@@ -269,7 +269,7 @@ class TestTiltCommands:
         await entity.async_open_cover_tilt()  # must not raise
 
     @pytest.mark.asyncio
-    async def test_close_tilt_sends_0(self):
+    async def test_close_tilt_sends_100(self):
         entity, gateway = _make_cover(
             [
                 {"role": "UpDown", "address": 200},
@@ -277,7 +277,7 @@ class TestTiltCommands:
             ]
         )
         await entity.async_close_cover_tilt()
-        gateway.async_send_telegram.assert_awaited_once_with(204, 0, "percent")
+        gateway.async_send_telegram.assert_awaited_once_with(204, 100, "percent")
 
     @pytest.mark.asyncio
     async def test_close_tilt_no_tilt_does_nothing(self):
@@ -334,7 +334,7 @@ class TestTiltCommands:
             ]
         )
         await entity.async_set_cover_tilt_position(**{"tilt_position": 45})
-        gateway.async_send_telegram.assert_awaited_once_with(204, 45, "percent")
+        gateway.async_send_telegram.assert_awaited_once_with(204, 55, "percent")
 
     @pytest.mark.asyncio
     async def test_set_tilt_no_tilt_does_nothing(self):


### PR DESCRIPTION
## Summary
- KNX `Lamelle%` follows the same 0=open/100=closed convention as `Höhe%` (fixed for main position in v1.1.6, see #197) — tilt read/write and the open/close-tilt commands passed values straight through instead of inverting.
- Closed blind reported `current_tilt_position: 100` instead of `0`; "open tilt" actually sent the closed value (100) to KNX and vice versa.
- `test_tilt_position_inverted_correctly` previously asserted the bug ("tilt passes through unchanged"); corrected, plus 3 sibling tests that baked in the same wrong assumption, plus 1 new regression test for the incoming path.

Fixes #197.

## Test plan
- [x] `test_tilt_position_inverted_correctly` + new `test_handle_tilt_update_inverted_correctly` (RED confirmed against old code, GREEN after fix)
- [x] `pytest tests/test_cover.py tests/test_cover_extended.py` — 85 passed
- [x] Gated suite: `pytest -m "not enable_socket" --ignore=tests/test_performance.py --ignore=tests/test_lxp_integration.py` — 972 passed
- [x] `pre-commit run --all-files` on changed files
- [x] README test-count badge bumped 1033 → 1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)