### PR TITLE
chore(release): bump to 1.2.2 for tilt-inversion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the LUXORliving Home Assistant integration will be
 documented in this file.
 
+## [1.2.2] - 2026-08-02
+
+### Fixed
+
+- **Cover tilt position inverted (#197)**: KNX `Lamelle%` follows the same 0=open/100=closed convention as `Höhe%` (fixed for main position in v1.1.6), but tilt read/write and the open/close-tilt commands passed values straight through. A closed blind reported `current_tilt_position: 100` instead of `0`, and "open tilt" sent the KNX-closed value (100) while "close tilt" sent the KNX-open value (0) — both commands were inverted. All four paths (`_handle_tilt_update`, `async_set_cover_tilt_position`, `async_open_cover_tilt`, `async_close_cover_tilt`) now apply the same `100 - x` inversion as position.
+
 ## [1.2.1] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.2.1-rc.9](https://github.com/phismith91/luxorliving/releases/tag/v1.2.1-rc.9) — pre-release: fixes H6 heat/cool state not syncing across devices sharing the mode-switch GA, corrects the Wetterstation Helligkeit Vorne/Links/Rechts sensor mapping (a 3-way rotation, not the simple rename shipped in rc.5), and raises the diagnostics export cap from 50 to 200 entities. Builds on the rc.5–rc.8 IP1 tunneling slot-exhaustion and zombie-tunnel-watchdog fixes. _Fallback: [v1.1.15-rc.1](https://github.com/phismith91/luxorliving/releases/tag/v1.1.15-rc.1) remains available._
+**Current release:** [v1.2.2-rc.1](https://github.com/phismith91/luxorliving/releases/tag/v1.2.2-rc.1) — pre-release: fixes cover tilt position being inverted (#197) — closed blinds reported tilt 100 instead of 0, and open/close-tilt commands sent the opposite KNX value from what they meant. Builds on the stable [v1.2.1](https://github.com/phismith91/luxorliving/releases/tag/v1.2.1) release.
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/custom_components/luxor_living/manifest.json
+++ b/custom_components/luxor_living/manifest.json
@@ -17,7 +17,7 @@
     "xknx>=3.13.0",
     "defusedxml>=0.7.1"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "zeroconf": [
     {
       "type": "_knxip._udp.local."

--- a/docs/releases/RELEASE_NOTES_v1.2.2.md
+++ b/docs/releases/RELEASE_NOTES_v1.2.2.md
@@ -1,0 +1,13 @@
+# Release Notes — v1.2.2
+
+Pre-release (`v1.2.2-rc.1`). Full detail per change in [CHANGELOG.md](../../CHANGELOG.md#122---2026-08-02).
+
+## Fixed
+
+- **Cover tilt position inverted (#197)**: KNX `Lamelle%` follows the same
+  0=open/100=closed convention as `Höhe%` (fixed for main position in
+  v1.1.6), but tilt read/write and the open/close-tilt commands passed
+  values straight through. A closed blind reported
+  `current_tilt_position: 100` instead of `0`, and "open tilt"/"close tilt"
+  sent the opposite KNX value from what they meant. All four tilt paths
+  now apply the same `100 - x` inversion as position.


### PR DESCRIPTION
## Summary
- Bumps manifest.json to 1.2.2, adds CHANGELOG entry, RELEASE_NOTES_v1.2.2.md, and README current-release link — release-prep for the #197 tilt-inversion fix merged in #198.
- Enables tagging `v1.2.2-rc.1` for pre-release once this merges.

## Test plan
- [x] `scripts/check_version_refs.sh` — all 6 checks pass
- [x] `scripts/check_release_notes.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)