### PR TITLE
fix(#201): retry reconnect after failed zombie-tunnel recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov](https://codecov.io/gh/phismith91/luxorliving/branch/main/graph/badge.svg)](https://codecov.io/gh/phismith91/luxorliving)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/phismith91/luxorliving?include_prereleases)](https://github.com/phismith91/luxorliving/releases)
 [![License](https://img.shields.io/github/license/phismith91/luxorliving.svg)](https://github.com/phismith91/luxorliving/blob/main/LICENSE)
-[![Tests: 1034](https://img.shields.io/badge/Tests-1034%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
+[![Tests: 1037](https://img.shields.io/badge/Tests-1037%20passing-brightgreen.svg)](https://github.com/phismith91/luxorliving/blob/main/docs/TESTS.md)
 
 Home Assistant custom integration for **Theben LUXORliving KNX** systems. Connects via the BAOS 777 IP1 gateway using a LXP project file for automatic entity discovery — lights, covers, climate, sensors and binary sensors, all created without any manual YAML.
 

--- a/custom_components/luxor_living/const.py
+++ b/custom_components/luxor_living/const.py
@@ -35,6 +35,9 @@ ZOMBIE_RECONNECT_COOLDOWN = (
     300  # seconds to wait after a zombie-triggered reconnect before arming again
 )
 ZOMBIE_RECOVERY_TIMEOUT = 120  # seconds before a stuck zombie-recovery (disconnect+setup) is abandoned, releasing _session_lock
+ZOMBIE_RECOVERY_RETRY_INTERVAL = (
+    60  # seconds between async_setup() retries after a failed zombie recovery
+)
 XKNX_STOP_TIMEOUT = 15  # seconds before a hanging xknx.stop() is abandoned during disconnect
 NOT_CONNECTED_LOG_INTERVAL = 60  # rate-limit "not connected" ERROR log to once per N seconds
 DEFAULT_LOG_LEVEL = "info"

--- a/custom_components/luxor_living/knx_gateway.py
+++ b/custom_components/luxor_living/knx_gateway.py
@@ -32,6 +32,7 @@ from .const import (
     ZOMBIE_CHECK_INTERVAL,
     ZOMBIE_ERROR_THRESHOLD,
     ZOMBIE_RECONNECT_COOLDOWN,
+    ZOMBIE_RECOVERY_RETRY_INTERVAL,
     ZOMBIE_RECOVERY_TIMEOUT,
 )
 from .rest_client import AuthenticationError, BAOSRestClient, TunnelingError
@@ -101,6 +102,7 @@ class LuxorKNXGateway:
         )  # monotonic time of last zombie-triggered reconnect ("never" — must not
         # collide with a low time.monotonic() value on a freshly booted host)
         self._zombie_recover_task: asyncio.Task | None = None
+        self._recovery_retry_task: asyncio.Task | None = None
         self._initial_read_pending: set[str] = set()  # Track pending initial reads
         self._ga_label_map: dict[str, list[str]] = {}
         self._ia_label_map: dict[str, list[str]] = {}
@@ -351,6 +353,10 @@ class LuxorKNXGateway:
         await self._cancel_task(self._zombie_watchdog_task)
         self._zombie_watchdog_task = None
 
+        # Cancel a pending zombie-recovery retry loop
+        await self._cancel_task(self._recovery_retry_task)
+        self._recovery_retry_task = None
+
         # Cancel pending debounce task so no orphaned coroutines remain
         if self._debounce_task and not self._debounce_task.done():
             self._debounce_task.cancel()
@@ -573,10 +579,11 @@ class LuxorKNXGateway:
                 _LOGGER.warning("Zombie-tunnel recovery complete (host=%s)", self.host)
             else:
                 _LOGGER.error(
-                    "Zombie-tunnel recovery failed to reconnect (host=%s) — "
-                    "reload the integration if the gateway remains unreachable",
+                    "Zombie-tunnel recovery failed to reconnect (host=%s) — " "retrying every %ds",
                     self.host,
+                    ZOMBIE_RECOVERY_RETRY_INTERVAL,
                 )
+                self._schedule_recovery_retry()
         except asyncio.TimeoutError:
             self._connected = False
             _LOGGER.error(
@@ -587,6 +594,52 @@ class LuxorKNXGateway:
             )
         except Exception as err:
             _LOGGER.error("Zombie-tunnel recovery failed (host=%s): %s", self.host, err)
+
+    def _schedule_recovery_retry(self) -> None:
+        """Start the retry loop unless one is already running."""
+        if self._recovery_retry_task and not self._recovery_retry_task.done():
+            return
+        self._recovery_retry_task = self.hass.async_create_task(
+            self._recovery_retry_loop(), name="luxor_recovery_retry"
+        )
+
+    async def _recovery_retry_loop(self) -> None:
+        """Keep retrying async_setup() after a failed zombie recovery.
+
+        Without this, one failed reconnect permanently kills self-healing:
+        the watchdog and session-refresh loops are only (re)started inside a
+        successful async_setup(), and async_disconnect() already cancelled
+        the old watchdog before the failed attempt — so nothing is left to
+        ever retry (confirmed on Marcus' 2026-08-10/08-12 logs: zero further
+        zombie/refresh log lines after one failed recovery, "Cannot read -
+        not connected" every minute until a physical bus restart).
+        """
+        try:
+            while True:
+                await asyncio.sleep(ZOMBIE_RECOVERY_RETRY_INTERVAL)
+                if self._connected:
+                    return  # something else already reconnected us
+                async with self._session_lock:
+                    if self._connected:
+                        return
+                    try:
+                        if await self.async_setup():
+                            _LOGGER.warning(
+                                "Reconnected to KNX Gateway %s:%s after zombie-recovery retry",
+                                self.host,
+                                self.port,
+                            )
+                            return
+                    except Exception as err:
+                        _LOGGER.error(
+                            "Zombie-recovery retry failed (host=%s), will retry in %ds: %s",
+                            self.host,
+                            ZOMBIE_RECOVERY_RETRY_INTERVAL,
+                            err,
+                        )
+        except asyncio.CancelledError:
+            _LOGGER.debug("Zombie-recovery retry loop cancelled")
+            raise
 
     def _on_connection_state_changed(self, state: XknxConnectionState) -> None:
         """Handle xknx connection state changes.

--- a/tests/test_knx_gateway.py
+++ b/tests/test_knx_gateway.py
@@ -1078,6 +1078,80 @@ class TestZombieWatchdog:
         assert not any("recovery complete" in m.lower() for m in messages)
 
     @pytest.mark.asyncio
+    async def test_async_zombie_recover_schedules_retry_when_setup_fails(self, mock_hass):
+        """A failed recovery must schedule a retry loop, not give up permanently.
+
+        Without this, one failed async_setup() (e.g. IP1 still holding the
+        just-abandoned slot) leaves NOTHING running to ever reconnect: the
+        watchdog and session-refresh loops are only (re)started inside a
+        successful async_setup(), and async_disconnect() already cancelled
+        the old watchdog before this attempt. Reproduces Marcus'
+        2026-08-10/08-12 logs: zero further zombie/refresh log lines after
+        one failed recovery, permanent lockup until a physical bus restart.
+        """
+        gateway = self._make_gateway(mock_hass, simulation_mode=True)
+
+        async def _fake_disconnect():
+            pass
+
+        async def _fake_setup_fails():
+            return False
+
+        gateway.async_disconnect = _fake_disconnect
+        gateway.async_setup = _fake_setup_fails
+
+        await gateway._async_zombie_recover()
+
+        mock_hass.async_create_task.assert_called_once()
+        scheduled_coro = mock_hass.async_create_task.call_args[0][0]
+        assert scheduled_coro.__name__ == "_recovery_retry_loop"
+        scheduled_coro.close()
+        assert gateway._recovery_retry_task is not None
+
+    @pytest.mark.asyncio
+    async def test_recovery_retry_loop_retries_until_setup_succeeds(self, mock_hass):
+        """Retry loop must keep calling async_setup() on an interval until it succeeds."""
+        from custom_components.luxor_living.const import ZOMBIE_RECOVERY_RETRY_INTERVAL
+
+        gateway = self._make_gateway(mock_hass, simulation_mode=True)
+        gateway._connected = False
+        setup_calls: list[int] = []
+
+        async def _fake_setup():
+            setup_calls.append(1)
+            return len(setup_calls) >= 2  # fails first attempt, succeeds second
+
+        gateway.async_setup = _fake_setup
+
+        sleep_calls: list[int] = []
+
+        async def _fake_sleep(interval: int) -> None:
+            sleep_calls.append(interval)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await gateway._recovery_retry_loop()
+
+        assert sleep_calls == [ZOMBIE_RECOVERY_RETRY_INTERVAL, ZOMBIE_RECOVERY_RETRY_INTERVAL]
+        assert len(setup_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_recovery_retry_loop_skips_setup_if_already_connected(self, mock_hass):
+        """If something else already reconnected, the loop must not double-connect."""
+        gateway = self._make_gateway(mock_hass, simulation_mode=True)
+        gateway._connected = True
+
+        async def _fake_setup():
+            raise AssertionError("must not call async_setup() while already connected")
+
+        gateway.async_setup = _fake_setup
+
+        async def _fake_sleep(interval: int) -> None:
+            pass
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await gateway._recovery_retry_loop()
+
+    @pytest.mark.asyncio
     async def test_async_zombie_recover_times_out_and_releases_lock(self, mock_hass, caplog):
         """A stuck async_disconnect() must not hold _session_lock forever.
 


### PR DESCRIPTION
Fixes #201.

## Root cause

Marcus reported the KNX bus locking up again on 2026-08-10 and 2026-08-12, needing a physical restart both times. Both attached logs show the exact same sequence:

1. Zombie tunnel detected → recovery runs → succeeds. Repeats every ~5min, 6-7 times.
2. One recovery attempt's `async_setup()` hits `E_NO_MORE_CONNECTIONS` (the just-abandoned tunnel's IP1 slot wasn't freed in time by the flush).
3. From that point on: **zero further zombie-watchdog or session-refresh log lines** — just `Cannot read - not connected to KNX gateway` every minute until the physical restart.

Why: the zombie watchdog and session-refresh background loops are only (re)started inside a *successful* `async_setup()`, and `async_disconnect()` had already cancelled the old watchdog before that failed attempt. So the very first failed reconnect permanently kills every mechanism that could have retried — nothing left running to self-heal.

## Fix

On a failed zombie recovery, schedule `_recovery_retry_loop()` — retries `async_setup()` every 60s (`ZOMBIE_RECOVERY_RETRY_INTERVAL`) until it succeeds or the gateway is torn down. Cancelled alongside the other background loops in `async_disconnect()`.

## Testing

TDD, 3 new tests in `TestZombieWatchdog`:
- retry gets scheduled when recovery's `async_setup()` fails
- retry loop keeps calling `async_setup()` on the interval until success
- retry loop skips a redundant `async_setup()` if already reconnected by something else

Gated suite: 975 passed.