### PR TITLE
docs: add #201 fix to v1.2.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ documented in this file.
 ### Fixed
 
 - **Cover tilt position inverted (#197)**: KNX `Lamelle%` follows the same 0=open/100=closed convention as `Höhe%` (fixed for main position in v1.1.6), but tilt read/write and the open/close-tilt commands passed values straight through. A closed blind reported `current_tilt_position: 100` instead of `0`, and "open tilt" sent the KNX-closed value (100) while "close tilt" sent the KNX-open value (0) — both commands were inverted. All four paths (`_handle_tilt_update`, `async_set_cover_tilt_position`, `async_open_cover_tilt`, `async_close_cover_tilt`) now apply the same `100 - x` inversion as position.
+- **Zombie-tunnel recovery could permanently kill all self-healing (#201)**: confirmed on two independent field logs (2026-08-10, 2026-08-12) — 6-7 successful zombie recoveries every ~5min, then one `async_setup()` attempt hit `E_NO_MORE_CONNECTIONS` (the just-abandoned tunnel's IP1 slot not freed in time), and from that point on the integration went completely silent: no further zombie/refresh log lines, just `Cannot read - not connected` every minute until a physical bus restart. Root cause: the zombie watchdog and session-refresh background loops are only (re)started inside a *successful* `async_setup()`, and `async_disconnect()` had already cancelled the old watchdog before the failed attempt — nothing was left running to ever retry. `_async_zombie_recover()` now schedules a retry loop on failure that keeps calling `async_setup()` every 60s until it succeeds.
 
 ## [1.2.1] - 2026-07-26
 

--- a/docs/releases/RELEASE_NOTES_v1.2.2.md
+++ b/docs/releases/RELEASE_NOTES_v1.2.2.md
@@ -1,6 +1,6 @@
 # Release Notes — v1.2.2
 
-Pre-release (`v1.2.2-rc.1`). Full detail per change in [CHANGELOG.md](../../CHANGELOG.md#122---2026-08-02).
+Pre-release (`v1.2.2-rc.2`). Full detail per change in [CHANGELOG.md](../../CHANGELOG.md#122---2026-08-02).
 
 ## Fixed
 
@@ -11,3 +11,14 @@ Pre-release (`v1.2.2-rc.1`). Full detail per change in [CHANGELOG.md](../../CHAN
   `current_tilt_position: 100` instead of `0`, and "open tilt"/"close tilt"
   sent the opposite KNX value from what they meant. All four tilt paths
   now apply the same `100 - x` inversion as position.
+- **Zombie-tunnel recovery could permanently kill all self-healing (#201,
+  rc.2)**: confirmed on two independent field logs (2026-08-10,
+  2026-08-12) — several successful zombie recoveries every ~5min, then one
+  reconnect attempt hit `E_NO_MORE_CONNECTIONS` (the just-abandoned
+  tunnel's IP1 slot not freed in time), after which the integration went
+  completely silent — no further zombie/refresh log lines, just
+  "not connected" errors until a physical bus restart. Root cause: the
+  watchdog and session-refresh loops are only restarted inside a
+  *successful* reconnect, so one failed attempt left nothing running to
+  ever retry. A failed recovery now schedules a retry every 60s until it
+  reconnects.


### PR DESCRIPTION
rc.2's release notes/CHANGELOG only mentioned the tilt fix (#197), missing the zombie-recovery-retry fix (#201) that rc.2 was actually tagged for. Adds it to both.