### PR TITLE
chore(ci): dedupe PR check runs, non-blocking test-count badge

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,8 @@
 name: Pre-commit checks
 
+# pull_request only — a push trigger alongside it ran every check twice per
+# PR-branch push (each push also fires the PR "synchronize" event).
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,10 @@
 name: Validate
 
+# push limited to main — an unrestricted push trigger alongside pull_request
+# ran hacs/hassfest twice per PR-branch push.
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/scripts/validate_readme.sh
+++ b/scripts/validate_readme.sh
@@ -40,12 +40,13 @@ TEST_COUNT=$(python -m pytest tests/ --collect-only -q 2>&1 | grep "tests collec
 echo "   Actual tests: $TEST_COUNT"
 
 # Check for various test count patterns: "212 tests", "212/212", "Tests: 212"
+# Warning only — a stale badge is cosmetic, not release-blocking, and failing
+# CI on every test addition just forces a manual README bump each time.
 if grep -qE "($TEST_COUNT tests|$TEST_COUNT/$TEST_COUNT|Tests:? $TEST_COUNT)" README.md; then
     echo "   ✅ Test count $TEST_COUNT found in README.md"
 else
     echo "   ⚠️  Test count $TEST_COUNT NOT mentioned in README.md"
-    echo "      (Search for older count and update)"
-    ERRORS=$((ERRORS + 1))
+    echo "      (Search for older count and update — warning only, not blocking)"
 fi
 echo ""
 


### PR DESCRIPTION
Two small workflow-hygiene fixes, prepared to ride along with the rc.4 → stable promotion:

1. **Every PR check ran twice.** `pre-commit.yml` and `validate.yml` triggered on both `push` and `pull_request`, so each PR-branch push ran pre-commit / validate-hacs / validate-hassfest double. Now `pull_request`-only (`validate.yml` keeps `push` on `main` + nightly schedule). Halves CI minutes and check-list noise.

2. **Stale test-count badge no longer fails CI.** `validate_readme.sh` failed the build whenever the README's `Tests: NNN` badge lagged the actual collection count — forcing a manual bump on every test addition (bit us in #202 and #204). Downgraded to a warning; the badge stays, just doesn't block.

No integration code touched.