### PR TITLE
chore(release): promote v1.2.2 to stable

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,8 @@
 name: Pre-commit checks
 
+# pull_request only — a push trigger alongside it ran every check twice per
+# PR-branch push (each push also fires the PR "synchronize" event).
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ on:
     inputs:
       tag:
         description:
-          "Tag to release (e.g. v0.8.0 or v0.8.0-rc.1) — tag must already exist"
+          "Tag to release (e.g. v1.2.2 or v1.2.2-rc.1). Created at the default
+          branch HEAD if it does not exist yet."
         required: true
 
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,10 @@
 name: Validate
 
+# push limited to main — an unrestricted push trigger alongside pull_request
+# ran hacs/hassfest twice per PR-branch push.
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the LUXORliving Home Assistant integration will be
 documented in this file.
 
-## [1.2.2] - 2026-08-02
+## [1.2.2] - 2026-08-16
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Entities are discovered and created automatically from your LXP project file.
 [Release Operations](https://github.com/phismith91/luxorliving/blob/main/docs/RELEASE_OPERATIONS.md) · [Incident Response](https://github.com/phismith91/luxorliving/blob/main/docs/INCIDENT_RESPONSE_RUNBOOK.md) · [Changelog](https://github.com/phismith91/luxorliving/blob/main/CHANGELOG.md)
 
 <!-- RELEASE_NOTES_START -->
-**Current release:** [v1.2.2-rc.1](https://github.com/phismith91/luxorliving/releases/tag/v1.2.2-rc.1) — pre-release: fixes cover tilt position being inverted (#197) — closed blinds reported tilt 100 instead of 0, and open/close-tilt commands sent the opposite KNX value from what they meant. Builds on the stable [v1.2.1](https://github.com/phismith91/luxorliving/releases/tag/v1.2.1) release.
+**Current release:** [v1.2.2](https://github.com/phismith91/luxorliving/releases/tag/v1.2.2) — fixes the KNX tunnel getting stuck after a failed reconnect (#201): a zombie-tunnel recovery that failed once used to disable all further self-healing, and teardown could leave live tunnel instances holding every IP1 slot until a physical bus restart. Also fixes cover tilt position being inverted (#197).
 <!-- RELEASE_NOTES_END -->
 
 ---

--- a/docs/releases/RELEASE_NOTES_v1.2.2.md
+++ b/docs/releases/RELEASE_NOTES_v1.2.2.md
@@ -1,6 +1,8 @@
 # Release Notes — v1.2.2
 
-Pre-release (`v1.2.2-rc.4`). Full detail per change in [CHANGELOG.md](../../CHANGELOG.md#122---2026-08-02).
+Stable release. Full detail per change in [CHANGELOG.md](../../CHANGELOG.md#122---2026-08-16).
+
+Validated through four release candidates (rc.1–rc.4) against real IP1 hardware.
 
 ## Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "luxor-living"
-version = "1.2.0"
+version = "1.2.2"
 description = "Theben LUXORliving integration for Home Assistant"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/validate_readme.sh
+++ b/scripts/validate_readme.sh
@@ -40,12 +40,13 @@ TEST_COUNT=$(python -m pytest tests/ --collect-only -q 2>&1 | grep "tests collec
 echo "   Actual tests: $TEST_COUNT"
 
 # Check for various test count patterns: "212 tests", "212/212", "Tests: 212"
+# Warning only — a stale badge is cosmetic, not release-blocking, and failing
+# CI on every test addition just forces a manual README bump each time.
 if grep -qE "($TEST_COUNT tests|$TEST_COUNT/$TEST_COUNT|Tests:? $TEST_COUNT)" README.md; then
     echo "   ✅ Test count $TEST_COUNT found in README.md"
 else
     echo "   ⚠️  Test count $TEST_COUNT NOT mentioned in README.md"
-    echo "      (Search for older count and update)"
-    ERRORS=$((ERRORS + 1))
+    echo "      (Search for older count and update — warning only, not blocking)"
 fi
 echo ""
 


### PR DESCRIPTION
Makes v1.2.2 ready to ship as stable. **Merging this is the only manual step** — after that, tagging `v1.2.2` publishes the release.

## What's in it

**Release preparation**
- Release notes: `Pre-release (v1.2.2-rc.4)` → stable
- CHANGELOG `[1.2.2]` date → actual release date (2026-08-16)
- README current-release block: still pointed at **rc.1**; now describes v1.2.2 and the #201 tunnel fixes that are the substance of this release
- `pyproject.toml` version **1.2.0 → 1.2.2** — had silently drifted from `manifest.json` (already 1.2.2 since the rc line); no gate catches this, found by hand

**Folded in from #205** (CI hygiene, was on hold for exactly this moment)
- `pre-commit.yml` / `validate.yml` no longer fire on both `push` and `pull_request` — every PR check was running twice
- `validate_readme.sh` test-count badge check downgraded to a warning; a stale badge is cosmetic and was failing the build on every test addition

## Verification

- `scripts/check_version_refs.sh` → PASSED (0 warnings)
- `scripts/validate_readme.sh` → PASSED
- Gated suite → 978 passed

Closes #205.